### PR TITLE
fix: log Brain auto-register errors and normalize MCP event timestamps

### DIFF
--- a/src/agentmemory/brain.py
+++ b/src/agentmemory/brain.py
@@ -109,7 +109,7 @@ class Brain:
             )
             conn.commit()
         except Exception as exc:
-            logging.getLogger(__name__).debug("agent auto-register failed: %s", exc)
+            logging.getLogger(__name__).warning("agent auto-register failed: %s", exc)
         return conn
     
     def remember(self, content: str, category: str = "general", tags: Optional[Union[str, List[str]]] = None, confidence: float = 1.0) -> int:

--- a/src/agentmemory/mcp_server.py
+++ b/src/agentmemory/mcp_server.py
@@ -622,14 +622,15 @@ def tool_event_add(agent_id: str, summary: str, event_type: str, detail: str = N
         return {"ok": False, "error": "importance must be between 0.0 and 1.0"}
     db = get_db()
     ensure_agent(db, agent_id)
+    created_at = _now_ts()
     cur = db.execute(
-        "INSERT INTO events (agent_id, event_type, summary, detail, project, importance) VALUES (?,?,?,?,?,?)",
-        (agent_id, event_type, summary, detail, project, importance)
+        "INSERT INTO events (agent_id, event_type, summary, detail, project, importance, created_at) VALUES (?,?,?,?,?,?,?)",
+        (agent_id, event_type, summary, detail, project, importance, created_at)
     )
     eid = cur.lastrowid
     log_access(db, agent_id, "write", "events", eid)
     db.commit(); db.close()
-    return {"ok": True, "event_id": eid}
+    return {"ok": True, "event_id": eid, "created_at": created_at}
 
 
 def tool_event_search(agent_id: str, query: str = None, event_type: str = None,


### PR DESCRIPTION
## Summary
- log Brain._db() auto-register failures instead of silently swallowing them
- make MCP event_add write an explicit UTC ISO created_at timestamp

## Why
- avoids masking real database/permission/corruption issues during agent auto-registration
- aligns MCP event writes with the repo's timestamp validation triggers

## Test Plan
- local Hermes MCP smoke test for event_add succeeded after restart
- python -m py_compile src/agentmemory/brain.py src/agentmemory/mcp_server.py
