### PR TITLE
feat(#32): behavioral tagging retroactive rescue via labile_until

### DIFF
--- a/bin/brainctl-mcp
+++ b/bin/brainctl-mcp
@@ -484,17 +484,50 @@ def tool_memory_search(agent_id: str, query: str, category: str = None,
     return {"ok": True, "count": len(results), "memories": results}
 
 
+_LABILE_RESCUE_THRESHOLD = 0.8   # importance >= this triggers retroactive labile tagging
+_LABILE_RESCUE_WINDOW_HOURS = 2  # look back this many hours for memories to rescue
+_LABILE_DURATION_HOURS = 2       # labile window extends this far past event write time
+
+
 def tool_event_add(agent_id: str, summary: str, event_type: str, detail: str = None,
                    project: str = None, importance: float = 0.5) -> dict:
     db = get_db()
+    now_ts = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
     cur = db.execute(
-        "INSERT INTO events (agent_id, event_type, summary, detail, project, importance) VALUES (?,?,?,?,?,?)",
-        (agent_id, event_type, summary, detail, project, importance)
+        "INSERT INTO events (agent_id, event_type, summary, detail, project, importance, created_at) VALUES (?,?,?,?,?,?,?)",
+        (agent_id, event_type, summary, detail, project, importance, now_ts)
     )
     eid = cur.lastrowid
     log_access(db, agent_id, "write", "events", eid)
+
+    labile_rescued = 0
+    if importance >= _LABILE_RESCUE_THRESHOLD:
+        # Behavioral tagging retroactive rescue (Redondo & Morris 2011):
+        # A high-salience event retroactively stabilizes memories written
+        # in the preceding window by extending their decay immunity.
+        from datetime import timedelta
+        now_dt = datetime.now()
+        window_start = (now_dt - timedelta(hours=_LABILE_RESCUE_WINDOW_HOURS)).strftime("%Y-%m-%dT%H:%M:%S")
+        labile_until = (now_dt + timedelta(hours=_LABILE_DURATION_HOURS)).strftime("%Y-%m-%dT%H:%M:%S")
+        rescued = db.execute(
+            """
+            UPDATE memories
+            SET labile_until = ?, labile_agent_id = ?
+            WHERE agent_id = ?
+              AND created_at >= ?
+              AND created_at <= ?
+              AND retired_at IS NULL
+              AND (labile_until IS NULL OR labile_until < ?)
+            """,
+            (labile_until, agent_id, agent_id, window_start, now_ts, labile_until),
+        )
+        labile_rescued = rescued.rowcount
+
     db.commit(); db.close()
-    return {"ok": True, "event_id": eid}
+    result = {"ok": True, "event_id": eid}
+    if labile_rescued:
+        result["labile_rescued"] = labile_rescued
+    return result
 
 
 def tool_event_search(agent_id: str, query: str = None, event_type: str = None,
@@ -1121,7 +1154,7 @@ TOOLS = [
     ),
     Tool(
         name="event_add",
-        description="Log an event to brain.db. Events are timestamped records of what happened.",
+        description="Log an event to brain.db. Events are timestamped records of what happened. If importance >= 0.8, retroactively tags memories written in the prior 2 hours with a labile window (behavioral tagging rescue), protecting them from decay until 2 hours after this event.",
         inputSchema={
             "type": "object",
             "properties": {

--- a/src/agentmemory/hippocampus.py
+++ b/src/agentmemory/hippocampus.py
@@ -864,17 +864,19 @@ def apply_decay(conn: sqlite3.Connection, now: Optional[datetime] = None) -> Dic
     _protected_select = ", protected" if _protected_col else ""
     _has_ab = has_column(conn, "memories", "alpha")  # Bayesian alpha/beta columns
     _ab_select = ", alpha, beta" if _has_ab else ""
+    _has_labile = has_column(conn, "memories", "labile_until")
+    _labile_select = ", labile_until" if _has_labile else ""
 
     rows = conn.execute(
         f"""
-        SELECT id, confidence, temporal_class, memory_type, created_at, last_recalled_at{_protected_select}{_ab_select}
+        SELECT id, confidence, temporal_class, memory_type, created_at, last_recalled_at{_protected_select}{_ab_select}{_labile_select}
         FROM memories
         WHERE retired_at IS NULL
         """
     ).fetchall()
 
     stats = {"scanned": len(rows), "skipped_permanent": 0, "skipped_protected": 0,
-             "skipped_has_dependents": 0, "updated": 0, "retired": 0}
+             "skipped_labile": 0, "skipped_has_dependents": 0, "updated": 0, "retired": 0}
 
     for row in rows:
         mem_id = row["id"]
@@ -886,6 +888,13 @@ def apply_decay(conn: sqlite3.Connection, now: Optional[datetime] = None) -> Dic
         if temporal_class == "permanent":
             stats["skipped_permanent"] += 1
             continue
+
+        # Behavioral tagging: memories in their labile window are immune to decay
+        if _has_labile:
+            labile_until = row["labile_until"]
+            if labile_until and labile_until > now_sql:
+                stats["skipped_labile"] += 1
+                continue
 
         half_life = HALF_LIFE_DAYS.get(temporal_class)
         if half_life is None:

--- a/src/agentmemory/mcp_server.py
+++ b/src/agentmemory/mcp_server.py
@@ -674,6 +674,11 @@ def tool_memory_search(agent_id: str, query: str, category: str = None,
     return {"ok": True, "count": len(results), "memories": results}
 
 
+_LABILE_RESCUE_THRESHOLD = 0.8   # importance >= this triggers retroactive labile tagging
+_LABILE_RESCUE_WINDOW_HOURS = 2  # look back this many hours for memories to rescue
+_LABILE_DURATION_HOURS = 2       # labile window extends this far past event write time
+
+
 def tool_event_add(agent_id: str, summary: str, event_type: str, detail: str = None,
                    project: str = None, importance: float = 0.5) -> dict:
     if event_type not in VALID_EVENT_TYPES:
@@ -682,14 +687,45 @@ def tool_event_add(agent_id: str, summary: str, event_type: str, detail: str = N
         return {"ok": False, "error": "importance must be between 0.0 and 1.0"}
     db = get_db()
     ensure_agent(db, agent_id)
+    now_ts = _now_ts()
     cur = db.execute(
         "INSERT INTO events (agent_id, event_type, summary, detail, project, importance, created_at) VALUES (?,?,?,?,?,?,?)",
-        (agent_id, event_type, summary, detail, project, importance, _now_ts())
+        (agent_id, event_type, summary, detail, project, importance, now_ts)
     )
     eid = cur.lastrowid
     log_access(db, agent_id, "write", "events", eid)
+
+    labile_rescued = 0
+    if importance >= _LABILE_RESCUE_THRESHOLD:
+        # Behavioral tagging retroactive rescue (Redondo & Morris 2011):
+        # A high-salience event retroactively stabilizes memories written
+        # in the preceding window by extending their decay immunity.
+        from datetime import timedelta
+        try:
+            now_dt = datetime.fromisoformat(now_ts)
+        except Exception:
+            now_dt = datetime.utcnow()
+        window_start = (now_dt - timedelta(hours=_LABILE_RESCUE_WINDOW_HOURS)).strftime("%Y-%m-%dT%H:%M:%S")
+        labile_until = (now_dt + timedelta(hours=_LABILE_DURATION_HOURS)).strftime("%Y-%m-%dT%H:%M:%S")
+        rescued = db.execute(
+            """
+            UPDATE memories
+            SET labile_until = ?, labile_agent_id = ?
+            WHERE agent_id = ?
+              AND created_at >= ?
+              AND created_at <= ?
+              AND retired_at IS NULL
+              AND (labile_until IS NULL OR labile_until < ?)
+            """,
+            (labile_until, agent_id, agent_id, window_start, now_ts, labile_until),
+        )
+        labile_rescued = rescued.rowcount
+
     db.commit(); db.close()
-    return {"ok": True, "event_id": eid}
+    result = {"ok": True, "event_id": eid}
+    if labile_rescued:
+        result["labile_rescued"] = labile_rescued
+    return result
 
 
 def tool_event_search(agent_id: str, query: str = None, event_type: str = None,
@@ -1511,7 +1547,7 @@ TOOLS = [
     ),
     Tool(
         name="event_add",
-        description="Log an event to brain.db. Events are timestamped records of what happened.",
+        description="Log an event to brain.db. Events are timestamped records of what happened. If importance >= 0.8, retroactively tags memories written in the prior 2 hours with a labile window (behavioral tagging rescue), protecting them from decay until 2 hours after this event.",
         inputSchema={
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Summary
- **`tool_event_add`**: when `importance >= 0.8`, retroactively sets `labile_until = now+2h` and `labile_agent_id` on memories written by the same agent in the preceding 2 hours
- **`apply_decay`**: memories inside their labile window (`labile_until > now`) are fully skipped — no confidence decay, no retirement
- Response includes `labile_rescued` count when the rescue fires
- MCP tool description updated to document the behavior
- Applied to both `src/agentmemory/mcp_server.py` and `bin/brainctl-mcp`

## Motivation
The `labile_until` and `labile_agent_id` columns existed in the `memories` schema but nothing ever wrote to them or read from them. This wires them up based on the behavioral tagging hypothesis (Redondo & Morris 2011): a high-salience event retroactively stabilizes weak memories that were laid down in the same temporal context (the "tagging" window).

Without this, an agent that writes several weak memories and then immediately writes a major decision event has those prior memories decay normally — losing the context that led to the decision. With labile rescue, the decision event tags the prior memories and protects them for 2 hours, giving the consolidation cycle time to promote them properly.

## Test plan
- [ ] Write a memory for agent `hermes`, then immediately call `event_add` with `importance=0.9` — verify the memory row has `labile_until` set ~2h in the future
- [ ] Run consolidation cycle while a memory is in its labile window — verify `skipped_labile` > 0 in decay stats and the memory is not retired
- [ ] Write event with `importance=0.5` — verify no labile tagging fires
- [ ] Write event with `importance=0.8` for agent A when agent B has memories in the window — verify only agent A's memories are tagged
- [ ] `labile_rescued` key only appears in response when rescue count > 0

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)