### PR TITLE
feat(#13): auto-check triggers on event_add for proactive surfacing

### DIFF
--- a/bin/brainctl-mcp
+++ b/bin/brainctl-mcp
@@ -632,6 +632,15 @@ def tool_event_add(agent_id: str, summary: str, event_type: str, detail: str = N
     result = {"ok": True, "event_id": eid}
     if labile_rescued:
         result["labile_rescued"] = labile_rescued
+
+    # Proactive surfacing — auto-check triggers against the new event summary.
+    try:
+        trigger_result = tool_trigger_check(agent_id, summary)
+        if trigger_result.get("ok") and trigger_result.get("count", 0) > 0:
+            result["triggered"] = trigger_result["triggers"]
+    except Exception:
+        pass
+
     return result
 
 
@@ -1261,7 +1270,7 @@ TOOLS = [
     ),
     Tool(
         name="event_add",
-        description="Log an event to brain.db. Events are timestamped records of what happened. If importance >= 0.8, retroactively tags memories written in the prior 2 hours with a labile window (behavioral tagging rescue), protecting them from decay until 2 hours after this event.",
+        description="Log an event to brain.db. Events are timestamped records of what happened. If importance >= 0.8, retroactively tags memories written in the prior 2 hours with a labile window (behavioral tagging rescue). Auto-checks all agent triggers against the event summary — any matching triggers are returned in the response as 'triggered' list.",
         inputSchema={
             "type": "object",
             "properties": {

--- a/src/agentmemory/mcp_server.py
+++ b/src/agentmemory/mcp_server.py
@@ -837,6 +837,17 @@ def tool_event_add(agent_id: str, summary: str, event_type: str, detail: str = N
     result = {"ok": True, "event_id": eid}
     if labile_rescued:
         result["labile_rescued"] = labile_rescued
+
+    # Proactive surfacing — auto-check triggers against the new event summary.
+    # Agents don't need to call trigger_check manually; any trigger that matches
+    # the event content fires here and is returned in the response payload.
+    try:
+        trigger_result = tool_trigger_check(agent_id, summary)
+        if trigger_result.get("ok") and trigger_result.get("count", 0) > 0:
+            result["triggered"] = trigger_result["triggers"]
+    except Exception:
+        pass
+
     return result
 
 
@@ -1661,7 +1672,7 @@ TOOLS = [
     ),
     Tool(
         name="event_add",
-        description="Log an event to brain.db. Events are timestamped records of what happened. If importance >= 0.8, retroactively tags memories written in the prior 2 hours with a labile window (behavioral tagging rescue), protecting them from decay until 2 hours after this event.",
+        description="Log an event to brain.db. Events are timestamped records of what happened. If importance >= 0.8, retroactively tags memories written in the prior 2 hours with a labile window (behavioral tagging rescue). Auto-checks all agent triggers against the event summary — any matching triggers are returned in the response as 'triggered' list.",
         inputSchema={
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Summary
- `tool_event_add` now calls `tool_trigger_check(agent_id, summary)` after every event
- Any matching triggers are returned in the response under `triggered` key (list of trigger dicts)
- Key absent when no triggers fire — backward-compatible
- Wrapped in try/except — a broken trigger store never blocks event logging

## Motivation
Proactive surfacing requires the system to react to events automatically, not wait for agents to poll. Triggers already exist (`trigger_create`, `trigger_check`) but only fire when an agent calls `trigger_check` explicitly. This wires them into the write path so the hippocampal pattern-completion loop closes: event logged → triggers checked → relevant memories surfaced in the same response.

## Test plan
- [ ] Create a trigger with keyword "deployment", then call `event_add(summary="starting deployment")` — verify `triggered` key appears in response with the matching trigger
- [ ] `event_add` with no matching triggers — verify `triggered` key is absent
- [ ] Delete all triggers, call `event_add` — verify no error and `triggered` key absent

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)