### PR TITLE
feat(#21): valence-gated memory encoding via affect_log

### DIFF
--- a/bin/brainctl-mcp
+++ b/bin/brainctl-mcp
@@ -299,10 +299,27 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
     except Exception:
         surprise, surprise_method = 0.7, "error"
 
-    # Lightweight W(m) pre-check: worthiness = surprise * importance * (1 - redundancy)
+    # Valence-gated encoding (McGaugh 2004 + Hamann 2001):
+    # Negative valence suppresses memory propagation; positive facilitates it.
+    _valence_scale = 1.0
+    try:
+        _valence_row = db.execute(
+            "SELECT valence FROM affect_log WHERE agent_id = ? ORDER BY created_at DESC LIMIT 1",
+            (agent_id,)
+        ).fetchone()
+        if _valence_row:
+            _v = float(_valence_row["valence"] or 0.0)
+            if _v < -0.5:
+                _valence_scale = 0.7
+            elif _v > 0.5:
+                _valence_scale = 1.15
+    except Exception:
+        pass
+
+    # Lightweight W(m) pre-check: worthiness = surprise * importance * (1 - redundancy) * valence
     importance_estimate = confidence
     _pre_redundancy = 0.5 if (surprise is not None and surprise < 0.2) else 0.0
-    _pre_worthiness = (surprise or 0.7) * importance_estimate * (1.0 - _pre_redundancy)
+    _pre_worthiness = (surprise or 0.7) * importance_estimate * (1.0 - _pre_redundancy) * _valence_scale
     if _pre_worthiness < 0.3 and not force:
         try:
             db.execute(
@@ -315,6 +332,7 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
                      "surprise": surprise,
                      "surprise_method": surprise_method,
                      "importance_estimate": round(importance_estimate, 4),
+                     "valence_scale": round(_valence_scale, 4),
                      "pre_worthiness": round(_pre_worthiness, 4),
                      "category": category,
                      "scope": scope,
@@ -443,6 +461,8 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
         pass
     db.commit(); db.close()
     result = {"ok": True, "memory_id": mid, "embedded": embedded, "worthiness_score": worthiness_score, "surprise_score": surprise, "surprise_method": surprise_method}
+    if _valence_scale != 1.0:
+        result["valence_scale"] = round(_valence_scale, 4)
     if pii_gate_info:
         result["pii_gate"] = pii_gate_info
     return result

--- a/src/agentmemory/mcp_server.py
+++ b/src/agentmemory/mcp_server.py
@@ -498,10 +498,29 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
     except Exception:
         pass
 
-    # Lightweight W(m) pre-check: worthiness = surprise * importance * (1 - redundancy) * arousal
+    # Valence-gated encoding (McGaugh 2004 + Hamann 2001):
+    # Negative valence (threat/aversion) suppresses memory propagation.
+    # Positive valence (reward/approach) facilitates propagation.
+    # Read agent's most recent affect_log valence and scale W(m) accordingly.
+    _valence_scale = 1.0
+    try:
+        _valence_row = db.execute(
+            "SELECT valence FROM affect_log WHERE agent_id = ? ORDER BY created_at DESC LIMIT 1",
+            (agent_id,)
+        ).fetchone()
+        if _valence_row:
+            _v = float(_valence_row["valence"] or 0.0)
+            if _v < -0.5:
+                _valence_scale = 0.7   # suppress: high-stress encoding is attenuated
+            elif _v > 0.5:
+                _valence_scale = 1.15  # propagate: positive state boosts encoding
+    except Exception:
+        pass
+
+    # Lightweight W(m) pre-check: worthiness = surprise * importance * (1 - redundancy) * arousal * valence
     importance_estimate = confidence
     _pre_redundancy = 0.5 if (surprise is not None and surprise < 0.2) else 0.0
-    _pre_worthiness = (surprise or 0.7) * importance_estimate * (1.0 - _pre_redundancy) * _arousal_gain
+    _pre_worthiness = (surprise or 0.7) * importance_estimate * (1.0 - _pre_redundancy) * _arousal_gain * _valence_scale
     if _pre_worthiness < 0.3 and not force:
         try:
             db.execute(
@@ -514,6 +533,7 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
                      "surprise": surprise,
                      "surprise_method": surprise_method,
                      "importance_estimate": round(importance_estimate, 4),
+                     "valence_scale": round(_valence_scale, 4),
                      "pre_worthiness": round(_pre_worthiness, 4),
                      "category": category,
                      "scope": scope,
@@ -646,6 +666,8 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
         pass
     db.commit(); db.close()
     result = {"ok": True, "memory_id": mid, "embedded": embedded, "worthiness_score": worthiness_score, "surprise_score": surprise, "surprise_method": surprise_method}
+    if _valence_scale != 1.0:
+        result["valence_scale"] = round(_valence_scale, 4)
     if pii_gate_info:
         result["pii_gate"] = pii_gate_info
     return result


### PR DESCRIPTION
## Summary
- Reads agent's most recent `affect_log.valence` before the W(m) pre-worthiness check
- `valence < -0.5` → 0.70x suppression factor; `valence > 0.5` → 1.15x propagation factor
- `valence_scale` appears in rejection log metadata and in success response when non-neutral
- No new tables — reads from existing `affect_log` (same table used by `affect_check`)

## Motivation
`affect_log` already captures valence per-agent but nothing was reading it at write time. The existing W(m) gate already incorporates arousal (`arousal_write_boost`). Valence is the missing half: arousal affects encoding strength, valence affects encoding direction. Hamann (2001) shows the valence effect is asymmetric — negative valence suppresses propagation while positive valence facilitates it. An agent in a negative affective state (after a failed task, an error event, etc.) should write fewer low-confidence memories to prevent contaminating the store with stress-encoded noise.

## Test plan
- [ ] Log a negative affect event (`valence=-0.8`), then call `memory_add` — verify `valence_scale=0.7` in response and that borderline memories are rejected at higher rate
- [ ] Log a positive affect event (`valence=0.8`), then call `memory_add` — verify `valence_scale=1.15` and borderline memories pass more easily
- [ ] `memory_add` with no prior affect_log — `valence_scale` absent from response (neutral)
- [ ] `memory_add` with `force=true` — valence gate still computes but gate bypass works normally

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)