### PR TITLE
feat: schema resonance, compositional replay, cosine-divergence boundary (#33 #7 #34)

### DIFF
--- a/src/agentmemory/mcp_server.py
+++ b/src/agentmemory/mcp_server.py
@@ -660,6 +660,66 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
             "alpha_floor": alpha_floor,
         }
 
+    # Schema resonance check (issue #33): VTA fast-track for congruent memories.
+    # If the new content has cosine similarity > 0.85 to ≥3 existing same-category
+    # memories, it fits an existing schema — write it as 'semantic' immediately,
+    # bypassing the episodic consolidation queue.
+    # Grounded in Sekeres et al. 2024: schema-congruent traces are rapidly integrated
+    # via mPFC→hippocampus pathway without multi-day systems consolidation.
+    _schema_resonance = 0.0
+    _schema_resonance_hit = False
+    if blob and memory_type == "episodic" and not force:
+        try:
+            _vdb_sr = _get_vec_db()
+            if _vdb_sr:
+                try:
+                    sr_rows = _vdb_sr.execute(
+                        "SELECT rowid, distance FROM vec_memories WHERE embedding MATCH ? AND k=?",
+                        (blob, 10)
+                    ).fetchall()
+                    if sr_rows:
+                        import struct as _sr_struct
+                        cand_n = len(blob) // 4
+                        cand_vec = list(_sr_struct.unpack(f"{cand_n}f", blob[:cand_n * 4]))
+                        high_sim_count = 0
+                        sim_scores = []
+                        for sr_row in sr_rows:
+                            sr_id = sr_row[0] if isinstance(sr_row, tuple) else sr_row["rowid"]
+                            # Filter to same category + agent
+                            m_row = db.execute(
+                                "SELECT category FROM memories WHERE id = ? AND retired_at IS NULL "
+                                "AND agent_id = ? AND category = ?",
+                                (sr_id, agent_id, category)
+                            ).fetchone()
+                            if not m_row:
+                                continue
+                            e_row = _vdb_sr.execute(
+                                "SELECT vector FROM embeddings WHERE source_table='memories' AND source_id=?",
+                                (sr_id,)
+                            ).fetchone()
+                            if not e_row:
+                                continue
+                            v_bytes = bytes(e_row[0] if isinstance(e_row, tuple) else e_row["vector"])
+                            n2 = len(v_bytes) // 4
+                            v2 = list(_sr_struct.unpack(f"{n2}f", v_bytes[:n2 * 4]))
+                            dot = sum(a * b for a, b in zip(cand_vec, v2))
+                            import math as _sr_math
+                            na = _sr_math.sqrt(sum(x * x for x in cand_vec))
+                            nb = _sr_math.sqrt(sum(x * x for x in v2))
+                            if na > 0 and nb > 0:
+                                sim = max(-1.0, min(1.0, dot / (na * nb)))
+                                sim_scores.append(sim)
+                                if sim > 0.85:
+                                    high_sim_count += 1
+                        if high_sim_count >= 3:
+                            memory_type = "semantic"
+                            _schema_resonance_hit = True
+                        _schema_resonance = round(max(sim_scores), 4) if sim_scores else 0.0
+                finally:
+                    _vdb_sr.close()
+        except Exception:
+            pass
+
     created_at = _now_ts()
     cur = db.execute(
         "INSERT INTO memories (agent_id, category, scope, content, confidence, tags, memory_type, "
@@ -697,7 +757,11 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
     db.commit(); db.close()
     result = {"ok": True, "memory_id": mid, "embedded": embedded, "worthiness_score": worthiness_score,
               "surprise_score": surprise, "surprise_method": surprise_method,
-              "source": source, "trust_score": source_trust}
+              "source": source, "trust_score": source_trust,
+              "memory_type": memory_type}
+    if _schema_resonance_hit:
+        result["schema_resonance"] = _schema_resonance
+        result["schema_resonance_fast_track"] = True
     if _valence_scale != 1.0:
         result["valence_scale"] = round(_valence_scale, 4)
     if pii_gate_info:

--- a/src/agentmemory/mcp_tools_consolidation.py
+++ b/src/agentmemory/mcp_tools_consolidation.py
@@ -330,6 +330,7 @@ def tool_consolidation_run(
     promote_threshold_ripple: int = 3,
     promote_threshold_confidence: float = 0.7,
     run_causal_mining: bool = True,
+    run_transitive_inference: bool = True,
     **kw,
 ) -> dict:
     """Run a consolidation pass over the replay queue.
@@ -351,6 +352,7 @@ def tool_consolidation_run(
         promote_threshold_ripple: Min ripple_tags for episodic→semantic promotion (default 3).
         promote_threshold_confidence: Min confidence for promotion (default 0.7).
         run_causal_mining: Whether to run mine_causal_chains after the memory pass (default True).
+        run_transitive_inference: Whether to run 2-hop KG transitive inference (default True).
     """
     limit = max(1, min(500, int(limit)))
     min_priority = float(min_priority)
@@ -411,6 +413,104 @@ def tool_consolidation_run(
             causal_stats = mine_causal_chains(db)
             db.commit()
 
+        # Step 5: Transitive KG inference (compositional replay, issue #7).
+        # For each processed memory, find its entity relations, then compose 2-hop
+        # paths A→B→C into derived edges A→(rel1+rel2)→C.
+        # Score = confidence(A→B) × confidence(B→C). Prune if score < 0.3.
+        # Store as knowledge_edges with source='compositional_replay'.
+        transitive_stats: dict = {"paths_scanned": 0, "edges_derived": 0}
+        if run_transitive_inference and processed_ids:
+            try:
+                now_ts = _now_sql()
+                paths_scanned = 0
+                edges_derived = 0
+
+                # For each entity that appears in knowledge_edges, walk 2-hop paths
+                # Extract entities linked to processed memories (via entity_relations or knowledge_edges)
+                placeholder = ",".join("?" * len(processed_ids))
+                linked_entities = db.execute(
+                    f"SELECT DISTINCT entity_id FROM entity_relations WHERE memory_id IN ({placeholder})",
+                    processed_ids,
+                ).fetchall()
+                linked_entity_ids = [r["entity_id"] if hasattr(r, "keys") else r[0] for r in linked_entities]
+
+                if not linked_entity_ids:
+                    # Fall back: check knowledge_edges for any entity with high centrality
+                    linked_entity_ids = [
+                        r["source_id"] if hasattr(r, "keys") else r[0]
+                        for r in db.execute(
+                            "SELECT DISTINCT source_id FROM knowledge_edges WHERE source_table='entities' LIMIT 20"
+                        ).fetchall()
+                    ]
+
+                for entity_a in linked_entity_ids[:50]:  # cap at 50 to prevent explosion
+                    # Get first-degree outgoing edges from A
+                    ab_edges = db.execute(
+                        "SELECT target_id, relation_type, confidence FROM knowledge_edges "
+                        "WHERE source_table='entities' AND source_id=? AND target_table='entities' "
+                        "AND confidence IS NOT NULL",
+                        (entity_a,),
+                    ).fetchall()
+
+                    for ab in ab_edges:
+                        entity_b = ab["target_id"] if hasattr(ab, "keys") else ab[1]
+                        rel_ab = ab["relation_type"] if hasattr(ab, "keys") else ab[2]
+                        conf_ab = float(ab["confidence"] if hasattr(ab, "keys") else ab[3] or 0.5)
+
+                        # Get first-degree outgoing edges from B (excluding back to A)
+                        bc_edges = db.execute(
+                            "SELECT target_id, relation_type, confidence FROM knowledge_edges "
+                            "WHERE source_table='entities' AND source_id=? AND target_table='entities' "
+                            "AND target_id != ? AND confidence IS NOT NULL LIMIT 10",
+                            (entity_b, entity_a),
+                        ).fetchall()
+
+                        for bc in bc_edges:
+                            paths_scanned += 1
+                            entity_c = bc["target_id"] if hasattr(bc, "keys") else bc[1]
+                            rel_bc = bc["relation_type"] if hasattr(bc, "keys") else bc[2]
+                            conf_bc = float(bc["confidence"] if hasattr(bc, "keys") else bc[3] or 0.5)
+
+                            derived_score = round(conf_ab * conf_bc, 4)
+                            if derived_score < 0.3:
+                                continue  # prune low-confidence derived edges
+
+                            # Check if this derived edge already exists (avoid duplicates)
+                            existing = db.execute(
+                                "SELECT id, confidence FROM knowledge_edges "
+                                "WHERE source_table='entities' AND source_id=? "
+                                "AND target_table='entities' AND target_id=? "
+                                "AND source='compositional_replay'",
+                                (entity_a, entity_c),
+                            ).fetchone()
+
+                            derived_rel = f"{rel_ab}+{rel_bc}"[:120] if rel_ab and rel_bc else "transitive"
+
+                            if existing:
+                                existing_conf = float(existing["confidence"] if hasattr(existing, "keys") else existing[1] or 0.0)
+                                if derived_score > existing_conf:
+                                    db.execute(
+                                        "UPDATE knowledge_edges SET confidence=?, relation_type=?, updated_at=? WHERE id=?",
+                                        (derived_score, derived_rel, now_ts,
+                                         existing["id"] if hasattr(existing, "keys") else existing[0]),
+                                    )
+                                    edges_derived += 1
+                            else:
+                                db.execute(
+                                    "INSERT INTO knowledge_edges "
+                                    "(source_table, source_id, target_table, target_id, relation_type, "
+                                    "confidence, source, created_at, updated_at) "
+                                    "VALUES ('entities',?,'entities',?,?,?,?,?,?)",
+                                    (entity_a, entity_c, derived_rel, derived_score,
+                                     "compositional_replay", now_ts, now_ts),
+                                )
+                                edges_derived += 1
+
+                db.commit()
+                transitive_stats = {"paths_scanned": paths_scanned, "edges_derived": edges_derived}
+            except Exception:
+                pass
+
         db.close()
 
         return {
@@ -419,6 +519,7 @@ def tool_consolidation_run(
             "promoted_to_semantic": len(promotion_ids),
             "promotion_ids": promotion_ids[:20],
             "causal_mining": causal_stats,
+            "transitive_inference": transitive_stats,
             "scope": scope,
             "min_priority": min_priority,
         }

--- a/src/agentmemory/mcp_tools_temporal.py
+++ b/src/agentmemory/mcp_tools_temporal.py
@@ -206,14 +206,39 @@ def detect_epoch_boundaries(
     min_window: int = 4,
     topic_shift_threshold: float = 0.2,
     min_boundary_distance: int = 8,
+    context_decay: float = 0.7,
+    cosine_divergence_threshold: float = 0.55,
 ) -> list[dict]:
+    """Detect epoch boundaries using time-gap and cosine-divergence signals.
+
+    The topic-shift signal uses a rolling context Counter (exponential decay
+    λ=context_decay) instead of comparing fixed left/right windows.  Each
+    incoming event is scored against the accumulated context; a high divergence
+    (1 - cosine_similarity > cosine_divergence_threshold) flags a boundary —
+    analogous to prediction error in temporal context models.
+    """
     candidates = []
     if len(events) < 2:
         return candidates
 
+    # Rolling context counter — exponential decay per event.
+    # context = decay * context + (1 - decay) * new_event_tokens
+    context_counter: Counter = Counter()
+
     for idx in range(1, len(events)):
         prev_ts = _parse_timestamp(events[idx - 1].get("created_at"))
         curr_ts = _parse_timestamp(events[idx].get("created_at"))
+
+        # Blend previous event's tokens into rolling context before checking current.
+        prev_tokens = _event_topic_tokens(events[idx - 1])
+        if not context_counter:
+            # Bootstrap on first event.
+            context_counter = Counter({k: float(v) for k, v in prev_tokens.items()})
+        else:
+            decayed = Counter({k: v * context_decay for k, v in context_counter.items()})
+            scaled_new = Counter({k: v * (1.0 - context_decay) for k, v in prev_tokens.items()})
+            context_counter = decayed + scaled_new
+
         if prev_ts is None or curr_ts is None:
             continue
 
@@ -223,40 +248,19 @@ def detect_epoch_boundaries(
         if gap_signal:
             reasons.append("time_gap")
 
-        left_slice = events[max(0, idx - window_size):idx]
-        right_slice = events[idx:min(len(events), idx + window_size)]
-        topic_similarity = None
+        # Cosine-divergence signal: how much does the current event diverge from context?
+        curr_tokens = _event_topic_tokens(events[idx])
+        cosine_div: float | None = None
+        topic_similarity: float | None = None
         topic_signal = False
-        left_top = None
-        right_top = None
-        if len(left_slice) >= min_window and len(right_slice) >= min_window:
-            left_counter: Counter = Counter()
-            right_counter: Counter = Counter()
-            left_projects = Counter(str(r.get("project")).strip().lower() for r in left_slice if r.get("project"))
-            right_projects = Counter(str(r.get("project")).strip().lower() for r in right_slice if r.get("project"))
-            for row in left_slice:
-                left_counter.update(_event_topic_tokens(row))
-            for row in right_slice:
-                right_counter.update(_event_topic_tokens(row))
-            topic_similarity = _counter_cosine(left_counter, right_counter)
-            left_top = left_counter.most_common(1)[0][0] if left_counter else None
-            right_top = right_counter.most_common(1)[0][0] if right_counter else None
-            strong_project_shift = False
-            if left_projects and right_projects:
-                left_proj, left_proj_count = left_projects.most_common(1)[0]
-                right_proj, right_proj_count = right_projects.most_common(1)[0]
-                left_share = left_proj_count / len(left_slice)
-                right_share = right_proj_count / len(right_slice)
-                strong_project_shift = left_proj != right_proj and left_share >= 0.5 and right_share >= 0.5
-            topic_signal = (
-                (strong_project_shift and topic_similarity <= max(topic_shift_threshold, 0.3))
-                or topic_similarity <= (topic_shift_threshold / 2.0)
-            ) and (
-                left_top
-                and right_top
-                and left_top != right_top
-                and gap_h >= 6
-            )
+        left_top = context_counter.most_common(1)[0][0] if context_counter else None
+        right_top = curr_tokens.most_common(1)[0][0] if curr_tokens else None
+
+        if context_counter and curr_tokens:
+            cosine_sim = _counter_cosine(curr_tokens, context_counter)
+            topic_similarity = round(cosine_sim, 3)
+            cosine_div = round(1.0 - cosine_sim, 3)
+            topic_signal = cosine_div > cosine_divergence_threshold and gap_h >= 1.0
             if topic_signal:
                 reasons.append("topic_shift")
 
@@ -266,15 +270,16 @@ def detect_epoch_boundaries(
         score = 0.0
         if gap_signal:
             score += min(gap_h / gap_hours, 3.0)
-        if topic_signal and topic_similarity is not None:
-            score += max(0.0, 1.0 - topic_similarity)
+        if topic_signal and cosine_div is not None:
+            score += cosine_div
 
         candidates.append({
             "boundary_index": idx,
             "boundary_at": events[idx].get("created_at"),
             "reasons": reasons,
             "gap_hours": round(gap_h, 2),
-            "topic_similarity": None if topic_similarity is None else round(topic_similarity, 3),
+            "topic_similarity": topic_similarity,
+            "cosine_divergence": cosine_div,
             "left_topic": left_top,
             "right_topic": right_top,
             "score": round(score, 3),


### PR DESCRIPTION
## Summary

- **#33 Schema resonance** (`tool_memory_add`): when a new episodic memory has ≥3 vector neighbors with cosine sim > 0.85, it's immediately classified as `semantic` — skipping the episodic consolidation delay. Grounded in Sekeres et al. 2024.
- **#7 Compositional replay** (`tool_consolidation_run` Step 5): after SWR-driven consolidation, walks 2-hop entity paths A→B→C in `knowledge_edges`, derives new edges scored `conf(A→B) × conf(B→C)`, prunes below 0.3, stores with `source='compositional_replay'`.
- **#34 Cosine-divergence boundary detection** (`detect_epoch_boundaries`): replaces the left/right sliding-window topic comparison with a rolling context Counter (exponential decay λ=0.7). Boundary fires when `1 - cosine(event_tokens, context)` exceeds `cosine_divergence_threshold` (default 0.55) — analogous to prediction error in temporal context models.

## Test plan

- [x] All 1113 existing tests pass
- [ ] Review schema resonance path in `tool_memory_add` (requires Ollama for live vector test)
- [ ] Review compositional replay output in `tool_consolidation_run` return dict (`transitive_inference` key)
- [ ] Review `cosine_divergence` field in epoch boundary output

🤖 Generated with [Claude Code](https://claude.com/claude-code)