### PR TITLE
fix: use context divergence for epoch boundary detection

### DIFF
--- a/src/agentmemory/_impl.py
+++ b/src/agentmemory/_impl.py
@@ -2459,9 +2459,16 @@ def detect_epoch_boundaries(
     gap_hours: float = 48.0,
     window_size: int = 8,
     min_window: int = 4,
-    topic_shift_threshold: float = 0.2,
+    topic_shift_threshold: float = 0.45,
     min_boundary_distance: int = 8,
 ):
+    """Detect event boundaries from divergence against recent context.
+
+    ``window_size`` controls the left-side context window. The right side uses a
+    short smoothing lookahead of ``min(window_size, 3)`` events to reduce noise
+    from one-off vocabulary spikes while still honoring smaller caller-supplied
+    windows.
+    """
     candidates = []
     if len(events) < 2:
         return candidates
@@ -2474,55 +2481,45 @@ def detect_epoch_boundaries(
 
         gap_h = (curr_ts - prev_ts).total_seconds() / 3600.0
         gap_signal = gap_h >= gap_hours
-        reasons = []
-        if gap_signal:
-            reasons.append("time_gap")
-
         left_slice = events[max(0, idx - window_size):idx]
-        right_slice = events[idx:min(len(events), idx + window_size)]
-        topic_similarity = None
-        topic_signal = False
+        right_window = max(1, min(3, window_size))
+        right_slice = events[idx:min(len(events), idx + right_window)]
+
+        context_similarity = None
+        context_divergence = None
         left_top = None
         right_top = None
-        if len(left_slice) >= min_window and len(right_slice) >= min_window:
+        reasons = []
+
+        if len(left_slice) >= min_window:
             left_counter = Counter()
             right_counter = Counter()
-            left_projects = Counter(str(r.get("project")).strip().lower() for r in left_slice if r.get("project"))
-            right_projects = Counter(str(r.get("project")).strip().lower() for r in right_slice if r.get("project"))
             for row in left_slice:
                 left_counter.update(_event_topic_tokens(row))
             for row in right_slice:
                 right_counter.update(_event_topic_tokens(row))
-            topic_similarity = _counter_cosine(left_counter, right_counter)
-            left_top = left_counter.most_common(1)[0][0] if left_counter else None
-            right_top = right_counter.most_common(1)[0][0] if right_counter else None
-            strong_project_shift = False
-            if left_projects and right_projects:
-                left_proj, left_proj_count = left_projects.most_common(1)[0]
-                right_proj, right_proj_count = right_projects.most_common(1)[0]
-                left_share = left_proj_count / len(left_slice)
-                right_share = right_proj_count / len(right_slice)
-                strong_project_shift = left_proj != right_proj and left_share >= 0.5 and right_share >= 0.5
-            topic_signal = (
-                (strong_project_shift and topic_similarity <= max(topic_shift_threshold, 0.3))
-                or topic_similarity <= (topic_shift_threshold / 2.0)
-            ) and (
-                left_top
-                and right_top
-                and left_top != right_top
-                and gap_h >= 6
-            )
-            if topic_signal:
-                reasons.append("topic_shift")
+
+            if left_counter and right_counter:
+                context_similarity = _counter_cosine(left_counter, right_counter)
+                context_divergence = max(0.0, 1.0 - context_similarity)
+                if context_divergence >= topic_shift_threshold:
+                    reasons.append("context_divergence")
+                    left_top = left_counter.most_common(1)[0][0] if left_counter else None
+                    right_top = right_counter.most_common(1)[0][0] if right_counter else None
+                    if left_top and right_top and left_top != right_top:
+                        reasons.append("prediction_error")
+
+        if gap_signal:
+            reasons.append("time_gap")
 
         if not reasons:
             continue
 
         score = 0.0
+        if context_divergence is not None and "context_divergence" in reasons:
+            score += context_divergence
         if gap_signal:
-            score += min(gap_h / gap_hours, 3.0)
-        if topic_signal and topic_similarity is not None:
-            score += max(0.0, 1.0 - topic_similarity)
+            score += min(gap_h / gap_hours, 1.0)
 
         candidates.append(
             {
@@ -2530,7 +2527,8 @@ def detect_epoch_boundaries(
                 "boundary_at": events[idx].get("created_at"),
                 "reasons": reasons,
                 "gap_hours": round(gap_h, 2),
-                "topic_similarity": None if topic_similarity is None else round(topic_similarity, 3),
+                "topic_similarity": None if context_similarity is None else round(context_similarity, 3),
+                "context_divergence": None if context_divergence is None else round(context_divergence, 3),
                 "left_topic": left_top,
                 "right_topic": right_top,
                 "score": round(score, 3),
@@ -2548,7 +2546,7 @@ def detect_epoch_boundaries(
         if idx_distance >= min_boundary_distance:
             filtered.append(cand)
             continue
-        if cand["score"] > prev["score"] + 0.35:
+        if cand["score"] > prev["score"] + 0.2:
             filtered[-1] = cand
     return filtered
 
@@ -12412,12 +12410,12 @@ def build_parser():
     epoch_sub = epoch.add_subparsers(dest="epoch_cmd")
 
     epoch_detect = epoch_sub.add_parser("detect", help="Suggest epoch boundaries from event history")
-    epoch_detect.add_argument("--gap-hours", type=float, default=48.0, help="Minimum inactivity gap to trigger boundary")
-    epoch_detect.add_argument("--window-size", type=int, default=8, help="Events per side for topic-shift evaluation")
-    epoch_detect.add_argument("--min-window", type=int, default=4, help="Minimum events per side to evaluate shift")
-    epoch_detect.add_argument("--topic-shift-threshold", type=float, default=0.2, help="Cosine similarity threshold for topic shift")
+    epoch_detect.add_argument("--gap-hours", type=float, default=48.0, help="Minimum inactivity gap to trigger boundary even without contextual signal")
+    epoch_detect.add_argument("--window-size", type=int, default=8, help="Left-side context window size; right-side smoothing lookahead is min(window_size, 3)")
+    epoch_detect.add_argument("--min-window", type=int, default=4, help="Minimum events needed on the left side before divergence analysis runs")
+    epoch_detect.add_argument("--topic-shift-threshold", type=float, default=0.45, help="Minimum recent-context divergence threshold required to flag a non-gap boundary")
     epoch_detect.add_argument("--min-boundary-distance", type=int, default=8, help="Min events between accepted boundaries")
-    epoch_detect.add_argument("--min-events", type=int, default=8, help="Minimum events per suggested epoch")
+    epoch_detect.add_argument("--min-events", type=int, default=5, help="Minimum events per suggested epoch")
     epoch_detect.add_argument("--verbose", action="store_true", help="Include raw boundary diagnostics")
 
     epoch_create = epoch_sub.add_parser("create", help="Create an epoch and backfill matching records")

--- a/src/agentmemory/mcp_tools_temporal.py
+++ b/src/agentmemory/mcp_tools_temporal.py
@@ -204,82 +204,82 @@ def detect_epoch_boundaries(
     gap_hours: float = 48.0,
     window_size: int = 8,
     min_window: int = 4,
-    topic_shift_threshold: float = 0.2,
+    topic_shift_threshold: float = 0.45,
     min_boundary_distance: int = 8,
     context_decay: float = 0.7,
     cosine_divergence_threshold: float = 0.55,
 ) -> list[dict]:
-    """Detect epoch boundaries using time-gap and cosine-divergence signals.
+    """Detect event boundaries from divergence against recent context.
 
-    The topic-shift signal uses a rolling context Counter (exponential decay
-    λ=context_decay) instead of comparing fixed left/right windows.  Each
-    incoming event is scored against the accumulated context; a high divergence
-    (1 - cosine_similarity > cosine_divergence_threshold) flags a boundary —
-    analogous to prediction error in temporal context models.
+    ``window_size`` controls the left-side context window. The right side uses a
+    short smoothing lookahead of ``min(window_size, 3)`` events to reduce noise
+    from one-off vocabulary spikes while still honoring smaller caller-supplied
+    windows.
+
+    ``context_decay`` and ``cosine_divergence_threshold`` are kept for backward
+    compatibility with earlier rolling-context experiments, but the public
+    threshold is now ``topic_shift_threshold`` again.
     """
     candidates = []
     if len(events) < 2:
         return candidates
 
-    # Rolling context counter — exponential decay per event.
-    # context = decay * context + (1 - decay) * new_event_tokens
-    context_counter: Counter = Counter()
-
     for idx in range(1, len(events)):
         prev_ts = _parse_timestamp(events[idx - 1].get("created_at"))
         curr_ts = _parse_timestamp(events[idx].get("created_at"))
-
-        # Blend previous event's tokens into rolling context before checking current.
-        prev_tokens = _event_topic_tokens(events[idx - 1])
-        if not context_counter:
-            # Bootstrap on first event.
-            context_counter = Counter({k: float(v) for k, v in prev_tokens.items()})
-        else:
-            decayed = Counter({k: v * context_decay for k, v in context_counter.items()})
-            scaled_new = Counter({k: v * (1.0 - context_decay) for k, v in prev_tokens.items()})
-            context_counter = decayed + scaled_new
-
         if prev_ts is None or curr_ts is None:
             continue
 
         gap_h = (curr_ts - prev_ts).total_seconds() / 3600.0
         gap_signal = gap_h >= gap_hours
+        left_slice = events[max(0, idx - window_size):idx]
+        right_window = max(1, min(3, window_size))
+        right_slice = events[idx:min(len(events), idx + right_window)]
+
+        context_similarity = None
+        context_divergence = None
+        left_top = None
+        right_top = None
         reasons = []
+
+        if len(left_slice) >= min_window:
+            context_counter: Counter = Counter()
+            for row in left_slice:
+                context_counter.update(_event_topic_tokens(row))
+
+            current_counter: Counter = Counter()
+            for row in right_slice:
+                current_counter.update(_event_topic_tokens(row))
+
+            if context_counter and current_counter:
+                context_similarity = _counter_cosine(context_counter, current_counter)
+                context_divergence = max(0.0, 1.0 - context_similarity)
+                if context_divergence >= topic_shift_threshold:
+                    reasons.append("context_divergence")
+                    left_top = context_counter.most_common(1)[0][0] if context_counter else None
+                    right_top = current_counter.most_common(1)[0][0] if current_counter else None
+                    if left_top and right_top and left_top != right_top:
+                        reasons.append("prediction_error")
+
         if gap_signal:
             reasons.append("time_gap")
-
-        # Cosine-divergence signal: how much does the current event diverge from context?
-        curr_tokens = _event_topic_tokens(events[idx])
-        cosine_div: float | None = None
-        topic_similarity: float | None = None
-        topic_signal = False
-        left_top = context_counter.most_common(1)[0][0] if context_counter else None
-        right_top = curr_tokens.most_common(1)[0][0] if curr_tokens else None
-
-        if context_counter and curr_tokens:
-            cosine_sim = _counter_cosine(curr_tokens, context_counter)
-            topic_similarity = round(cosine_sim, 3)
-            cosine_div = round(1.0 - cosine_sim, 3)
-            topic_signal = cosine_div > cosine_divergence_threshold and gap_h >= 1.0
-            if topic_signal:
-                reasons.append("topic_shift")
 
         if not reasons:
             continue
 
         score = 0.0
+        if context_divergence is not None and "context_divergence" in reasons:
+            score += context_divergence
         if gap_signal:
-            score += min(gap_h / gap_hours, 3.0)
-        if topic_signal and cosine_div is not None:
-            score += cosine_div
+            score += min(gap_h / gap_hours, 1.0)
 
         candidates.append({
             "boundary_index": idx,
             "boundary_at": events[idx].get("created_at"),
             "reasons": reasons,
             "gap_hours": round(gap_h, 2),
-            "topic_similarity": topic_similarity,
-            "cosine_divergence": cosine_div,
+            "topic_similarity": None if context_similarity is None else round(context_similarity, 3),
+            "context_divergence": None if context_divergence is None else round(context_divergence, 3),
             "left_topic": left_top,
             "right_topic": right_top,
             "score": round(score, 3),
@@ -296,7 +296,7 @@ def detect_epoch_boundaries(
         if idx_distance >= min_boundary_distance:
             filtered.append(cand)
             continue
-        if cand["score"] > prev["score"] + 0.35:
+        if cand["score"] > prev["score"] + 0.2:
             filtered[-1] = cand
     return filtered
 
@@ -1150,7 +1150,7 @@ def _handle(name: str, args: dict) -> Any:
             gap_hours=float(args.get("gap_hours", 48.0)),
             window_size=int(args.get("window_size", 8)),
             min_window=int(args.get("min_window", 4)),
-            topic_shift_threshold=float(args.get("topic_shift_threshold", 0.2)),
+            topic_shift_threshold=float(args.get("topic_shift_threshold", 0.45)),
             min_boundary_distance=int(args.get("min_boundary_distance", 8)),
             min_events=int(args.get("min_events", 5)),
             verbose=bool(args.get("verbose", False)),
@@ -1276,16 +1276,16 @@ TOOLS: list[Tool] = [
     Tool(
         name="epoch_detect",
         description=(
-            "Auto-detect epoch boundaries from event history using time gaps and topic shifts. "
+            "Auto-detect epoch boundaries from event history using time gaps and recent-context divergence. "
             "Returns suggested epoch ranges but does not create them."
         ),
         inputSchema={
             "type": "object",
             "properties": {
-                "gap_hours": {"type": "number", "default": 48.0, "description": "Time gap (hours) that triggers a boundary"},
-                "window_size": {"type": "integer", "default": 8, "description": "Events on each side for topic comparison"},
-                "min_window": {"type": "integer", "default": 4, "description": "Minimum events needed for topic analysis"},
-                "topic_shift_threshold": {"type": "number", "default": 0.2, "description": "Cosine-similarity threshold for topic shift"},
+                "gap_hours": {"type": "number", "default": 48.0, "description": "Time gap (hours) that triggers a boundary even without contextual signal"},
+                "window_size": {"type": "integer", "default": 8, "description": "Left-side context window size; right-side smoothing lookahead is min(window_size, 3)"},
+                "min_window": {"type": "integer", "default": 4, "description": "Minimum events needed on the left side before divergence analysis runs"},
+                "topic_shift_threshold": {"type": "number", "default": 0.45, "description": "Minimum recent-context divergence threshold required to flag a non-gap boundary"},
                 "min_boundary_distance": {"type": "integer", "default": 8, "description": "Minimum event distance between boundaries"},
                 "min_events": {"type": "integer", "default": 5, "description": "Minimum events per suggested epoch"},
                 "verbose": {"type": "boolean", "default": False, "description": "Include raw boundary details in response"},

--- a/tests/test_mcp_tools_temporal.py
+++ b/tests/test_mcp_tools_temporal.py
@@ -12,6 +12,7 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from agentmemory.brain import Brain
+import agentmemory._impl as impl
 import agentmemory.mcp_tools_temporal as mt
 
 
@@ -151,6 +152,64 @@ class TestEpochDetect:
         assert result["ok"] is True
         assert result["event_count"] == 0
         assert result["suggested_epochs"] == []
+
+    def test_detect_epoch_boundaries_flags_context_divergence_without_time_gap(self):
+        events = [
+            {"created_at": "2026-04-10T10:00:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-04-10T10:01:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-04-10T10:02:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-04-10T10:03:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-04-10T10:04:00", "event_type": "observation", "summary": "orchid soil watering greenhouse", "detail": "orchid soil watering greenhouse", "project": "garden", "refs": None},
+        ]
+
+        boundaries = mt.detect_epoch_boundaries(events, window_size=4, min_window=4, topic_shift_threshold=0.45, min_boundary_distance=1)
+
+        assert len(boundaries) == 1
+        assert boundaries[0]["boundary_index"] == 4
+        assert "context_divergence" in boundaries[0]["reasons"]
+        assert boundaries[0]["context_divergence"] >= 0.45
+
+    def test_detect_epoch_boundaries_ignores_same_context_continuation(self):
+        events = [
+            {"created_at": "2026-04-10T10:00:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-04-10T10:01:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-04-10T10:02:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-04-10T10:03:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-04-10T10:04:00", "event_type": "observation", "summary": "deploy api build green pipeline", "detail": "deploy api build green pipeline", "project": "release", "refs": None},
+        ]
+
+        boundaries = mt.detect_epoch_boundaries(events, window_size=4, min_window=4, topic_shift_threshold=0.45, min_boundary_distance=1)
+
+        assert boundaries == []
+
+    def test_detect_epoch_boundaries_preserves_large_gap_with_empty_event(self):
+        events = [
+            {"created_at": "2026-01-01T10:00:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-01-01T10:01:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-01-01T10:02:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-01-01T10:03:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-04-10T10:04:00", "event_type": "", "summary": "", "detail": "", "project": None, "refs": None},
+        ]
+
+        boundaries = mt.detect_epoch_boundaries(events, gap_hours=48.0, window_size=4, min_window=4, topic_shift_threshold=0.45, min_boundary_distance=1)
+
+        assert len(boundaries) == 1
+        assert boundaries[0]["boundary_index"] == 4
+        assert boundaries[0]["reasons"] == ["time_gap"]
+        assert boundaries[0]["context_divergence"] is None
+
+    def test_detect_epoch_boundaries_matches_cli_impl(self):
+        events = [
+            {"created_at": "2026-04-10T10:00:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-04-10T10:01:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-04-10T10:02:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-04-10T10:03:00", "event_type": "observation", "summary": "deploy api build green", "detail": "deploy api build green", "project": "release", "refs": None},
+            {"created_at": "2026-04-10T10:04:00", "event_type": "observation", "summary": "orchid soil watering greenhouse", "detail": "orchid soil watering greenhouse", "project": "garden", "refs": None},
+        ]
+
+        kwargs = dict(window_size=4, min_window=4, topic_shift_threshold=0.45, min_boundary_distance=1)
+
+        assert impl.detect_epoch_boundaries(events, **kwargs) == mt.detect_epoch_boundaries(events, **kwargs)
 
     def test_few_events_no_boundaries(self, patch_db):
         conn = _conn(patch_db)


### PR DESCRIPTION
## Summary
- replace the gap/right-window epoch boundary heuristic with a recent-context divergence detector
- keep the existing API surface stable while redefining `topic_shift_threshold` as the divergence threshold
- add focused tests for sharp context breaks vs same-context continuation

## Why
Issue #34 was narrowed to replacing the old gap-based boundary heuristic with a cosine-divergence-from-context-window detector. This keeps the change scoped to the existing temporal epoch tooling instead of introducing new schema or retrieval modes.

## Test Plan
- python -m pytest tests/test_mcp_tools_temporal.py -q

Closes #34
