### PR TITLE
feat: D-MEM RPE routing — three-tier write gate (issue #31)

### DIFF
--- a/MCP_SERVER.md
+++ b/MCP_SERVER.md
@@ -42,7 +42,7 @@ Add to `.vscode/mcp.json` or User Settings:
 docker run -v ~/.agentmemory:/data -e BRAIN_DB=/data/brain.db ghcr.io/yourorg/brainctl-mcp
 ```
 
-## Available Tools (186)
+## Available Tools (188)
 
 | Tool | Description |
 |------|-------------|
@@ -91,6 +91,8 @@ docker run -v ~/.agentmemory:/data -e BRAIN_DB=/data/brain.db ghcr.io/yourorg/br
 | `consolidation_schedule` | Predict memories likely to be needed soon and store forecasts |
 | `allostatic_prime` | Boost replay_priority for pending forecasts before demand arrives |
 | `demand_forecast` | Show consolidation forecasts with signal_source and confidence |
+| `memory_promote` | Promote a CONSTRUCT_ONLY memory to FULL_EVOLUTION (embed + FTS index) |
+| `tier_stats` | Show write-tier distribution (full/construct) for an agent |
 
 ## Environment Variables
 

--- a/bin/brainctl-mcp
+++ b/bin/brainctl-mcp
@@ -471,11 +471,22 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
             "alpha_floor": alpha_floor,
         }
 
+    # D-MEM RPE three-tier routing (issue #31)
+    # score < 0.3 → SKIP (already rejected above)
+    # 0.3 ≤ score < 0.7 → CONSTRUCT_ONLY (no embed/FTS)
+    # score ≥ 0.7 or None → FULL_EVOLUTION (embed + FTS)
+    if worthiness_score is not None and not force and worthiness_score < 0.7:
+        write_tier = "construct"
+        do_index = 0
+    else:
+        write_tier = "full"
+        do_index = 1
+
     cur = db.execute(
         "INSERT INTO memories (agent_id, category, scope, content, confidence, tags, memory_type, "
-        "supersedes_id, alpha, trust_score) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        "supersedes_id, alpha, trust_score, write_tier, indexed) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
         (agent_id, category, scope, content, confidence, tags_json, memory_type,
-         supersedes_id, float(alpha_floor), source_trust)
+         supersedes_id, float(alpha_floor), source_trust, write_tier, do_index)
     )
     mid = cur.lastrowid
 
@@ -487,25 +498,27 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
             pass
 
     log_access(db, agent_id, "write", "memories", mid)
-    # Embed on write — reuse blob computed above for the gate
+    # Embed on write — only for FULL_EVOLUTION tier
     embedded = False
-    try:
-        if not blob:
-            blob = _embed_safe(content)
-        if blob:
-            vdb = _get_vec_db()
-            if vdb:
-                vdb.execute("INSERT OR REPLACE INTO vec_memories(rowid, embedding) VALUES (?,?)", (mid, blob))
-                vdb.execute(
-                    "INSERT OR IGNORE INTO embeddings (source_table, source_id, model, dimensions, vector) VALUES (?,?,?,?,?)",
-                    ("memories", mid, EMBED_MODEL, 768, blob)
-                )
-                vdb.commit(); vdb.close()
-                embedded = True
-    except Exception:
-        pass
+    if do_index:
+        try:
+            if not blob:
+                blob = _embed_safe(content)
+            if blob:
+                vdb = _get_vec_db()
+                if vdb:
+                    vdb.execute("INSERT OR REPLACE INTO vec_memories(rowid, embedding) VALUES (?,?)", (mid, blob))
+                    vdb.execute(
+                        "INSERT OR IGNORE INTO embeddings (source_table, source_id, model, dimensions, vector) VALUES (?,?,?,?,?)",
+                        ("memories", mid, EMBED_MODEL, 768, blob)
+                    )
+                    vdb.commit(); vdb.close()
+                    embedded = True
+        except Exception:
+            pass
     db.commit(); db.close()
     result = {"ok": True, "memory_id": mid, "embedded": embedded, "worthiness_score": worthiness_score,
+              "write_tier": write_tier,
               "surprise_score": surprise, "surprise_method": surprise_method,
               "source": source, "trust_score": source_trust}
     if _valence_scale != 1.0:
@@ -1963,6 +1976,23 @@ TOOLS = [
             },
         },
     ),
+    Tool(
+        name="memory_promote",
+        description="Promote a CONSTRUCT_ONLY memory to FULL_EVOLUTION: embed + FTS index. Sets write_tier='full', indexed=1. Idempotent.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "memory_id": {"type": "integer", "description": "ID of memory to promote"},
+                "dry_run": {"type": "boolean", "default": False},
+            },
+            "required": ["memory_id"],
+        },
+    ),
+    Tool(
+        name="tier_stats",
+        description="Show write-tier distribution (full/construct) for an agent, including unindexed CONSTRUCT_ONLY count.",
+        inputSchema={"type": "object", "properties": {}},
+    ),
 ]
 
 # ---------------------------------------------------------------------------
@@ -2734,6 +2764,89 @@ def tool_demand_forecast(agent_id="mcp-client", include_fulfilled=False, limit=2
 
 
 # ---------------------------------------------------------------------------
+# D-MEM promotion tools (issue #31)
+# ---------------------------------------------------------------------------
+
+def tool_memory_promote(agent_id="mcp-client", memory_id=None, dry_run=False, **kw):
+    """Promote a CONSTRUCT_ONLY memory to FULL_EVOLUTION (embed + FTS index)."""
+    if not memory_id:
+        return {"ok": False, "error": "memory_id is required"}
+    db = get_db()
+    try:
+        row = db.execute(
+            "SELECT id, content, write_tier, indexed FROM memories WHERE id = ? AND agent_id = ?",
+            (memory_id, agent_id),
+        ).fetchone()
+        if not row:
+            return {"ok": False, "error": f"Memory {memory_id} not found for agent {agent_id}"}
+        if row["write_tier"] == "full" and row["indexed"] == 1:
+            return {"ok": True, "memory_id": memory_id, "already_full": True}
+        if dry_run:
+            return {"ok": True, "dry_run": True, "memory_id": memory_id,
+                    "write_tier": row["write_tier"], "indexed": row["indexed"]}
+        content = row["content"]
+        blob = _embed_safe(content)
+        embedded = False
+        if blob:
+            vdb = _get_vec_db()
+            if vdb:
+                try:
+                    vdb.execute("INSERT OR REPLACE INTO vec_memories(rowid, embedding) VALUES (?,?)", (memory_id, blob))
+                    vdb.execute(
+                        "INSERT OR IGNORE INTO embeddings (source_table, source_id, model, dimensions, vector) "
+                        "VALUES (?,?,?,?,?)",
+                        ("memories", memory_id, EMBED_MODEL, 768, blob),
+                    )
+                    vdb.commit()
+                    embedded = True
+                finally:
+                    vdb.close()
+        # Promotion: triggers memories_fts_update_insert via indexed 0→1
+        db.execute(
+            "UPDATE memories SET write_tier = 'full', indexed = 1, promoted_at = ? WHERE id = ?",
+            (_now_ts(), memory_id),
+        )
+        db.commit()
+        try:
+            db.execute(
+                "INSERT INTO events (agent_id, event_type, summary, created_at) VALUES (?, 'memory_promoted', ?, ?)",
+                (agent_id, f"Promoted memory {memory_id} to FULL_EVOLUTION", _now_ts()),
+            )
+            db.commit()
+        except Exception:
+            pass
+        return {"ok": True, "memory_id": memory_id, "promoted": True, "embedded": embedded}
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+    finally:
+        db.close()
+
+
+def tool_tier_stats(agent_id="mcp-client", **kw):
+    """Show write-tier distribution for an agent."""
+    db = get_db()
+    try:
+        rows = db.execute(
+            "SELECT write_tier, COUNT(*) as cnt FROM memories WHERE agent_id = ? AND retired_at IS NULL "
+            "GROUP BY write_tier",
+            (agent_id,),
+        ).fetchall()
+        if not rows:
+            return {"ok": True, "agent_id": agent_id, "total": 0, "tiers": {}}
+        total = sum(r["cnt"] for r in rows)
+        tiers = {r["write_tier"]: {"count": r["cnt"], "pct": round(100.0 * r["cnt"] / total, 1)} for r in rows}
+        unindexed = db.execute(
+            "SELECT COUNT(*) as cnt FROM memories WHERE agent_id = ? AND indexed = 0 AND retired_at IS NULL",
+            (agent_id,),
+        ).fetchone()["cnt"]
+        return {"ok": True, "agent_id": agent_id, "total": total, "tiers": tiers, "unindexed_count": unindexed}
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
 # MCP Server
 # ---------------------------------------------------------------------------
 
@@ -2787,6 +2900,8 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         "consolidation_schedule": tool_consolidation_schedule,
         "allostatic_prime": tool_allostatic_prime,
         "demand_forecast": tool_demand_forecast,
+        "memory_promote": tool_memory_promote,
+        "tier_stats": tool_tier_stats,
     }
 
     fn = dispatch.get(name)

--- a/db/migrations/031_dmem_write_tiers.sql
+++ b/db/migrations/031_dmem_write_tiers.sql
@@ -1,0 +1,46 @@
+-- Migration 031: D-MEM RPE routing — three-tier write gate (issue #31)
+-- Adds write_tier (skip/construct/full), indexed flag, and promoted_at timestamp
+-- to memories table, plus memory_stats for long-term utility estimation.
+-- Updates FTS5 triggers to only index when indexed = 1.
+
+ALTER TABLE memories ADD COLUMN write_tier TEXT NOT NULL DEFAULT 'full'
+    CHECK(write_tier IN ('skip', 'construct', 'full'));
+ALTER TABLE memories ADD COLUMN indexed INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE memories ADD COLUMN promoted_at TEXT DEFAULT NULL;
+
+-- memory_stats: per-(agent, category, scope) average recall rate for long-term utility
+CREATE TABLE IF NOT EXISTS memory_stats (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id TEXT NOT NULL,
+    category TEXT NOT NULL,
+    scope TEXT NOT NULL DEFAULT 'global',
+    avg_recall_rate REAL NOT NULL DEFAULT 0.5,
+    sample_count INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S','now')),
+    UNIQUE(agent_id, category, scope)
+);
+CREATE INDEX IF NOT EXISTS idx_memory_stats_agent ON memory_stats(agent_id, category, scope);
+
+-- Update FTS5 triggers to skip unindexed memories.
+-- Insert: only index when indexed = 1
+DROP TRIGGER IF EXISTS memories_fts_insert;
+CREATE TRIGGER memories_fts_insert AFTER INSERT ON memories WHEN new.indexed = 1 BEGIN
+    INSERT INTO memories_fts(rowid, content, category, tags)
+    VALUES (new.id, new.content, new.category, new.tags);
+END;
+
+-- Update: remove old FTS entry if it was indexed; add new if now indexed.
+-- Split into two triggers to handle 0→1 promotion correctly.
+DROP TRIGGER IF EXISTS memories_fts_update;
+DROP TRIGGER IF EXISTS memories_fts_update_delete;
+DROP TRIGGER IF EXISTS memories_fts_update_insert;
+
+CREATE TRIGGER memories_fts_update_delete AFTER UPDATE ON memories WHEN old.indexed = 1 BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content, category, tags)
+    VALUES ('delete', old.id, old.content, old.category, old.tags);
+END;
+
+CREATE TRIGGER memories_fts_update_insert AFTER UPDATE ON memories WHEN new.indexed = 1 BEGIN
+    INSERT INTO memories_fts(rowid, content, category, tags)
+    VALUES (new.id, new.content, new.category, new.tags);
+END;

--- a/src/agentmemory/db/init_schema.sql
+++ b/src/agentmemory/db/init_schema.sql
@@ -40,7 +40,7 @@ CREATE TABLE memories (
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now')),
     retired_at TEXT                                    -- soft delete
-, epoch_id INTEGER REFERENCES epochs(id), temporal_class TEXT NOT NULL DEFAULT 'medium', validation_agent_id TEXT REFERENCES agents(id), validated_at TEXT, trust_score REAL DEFAULT 1.0, derived_from_ids TEXT, retracted_at TEXT, retraction_reason TEXT, version INTEGER NOT NULL DEFAULT 1, memory_type TEXT NOT NULL DEFAULT 'episodic' CHECK(memory_type IN ('episodic','semantic')), protected INTEGER NOT NULL DEFAULT 0, salience_score REAL NOT NULL DEFAULT 0.0, gw_broadcast INTEGER NOT NULL DEFAULT 0, visibility TEXT NOT NULL DEFAULT 'public', read_acl TEXT, ewc_importance REAL NOT NULL DEFAULT 0.0, alpha REAL DEFAULT 1.0, beta  REAL DEFAULT 1.0, confidence_alpha REAL GENERATED ALWAYS AS (alpha) VIRTUAL, confidence_beta  REAL GENERATED ALWAYS AS (beta)  VIRTUAL, confidence_phase REAL NOT NULL DEFAULT 0.0, hilbert_projection BLOB DEFAULT NULL, coherence_syndrome TEXT DEFAULT NULL, decoherence_rate REAL DEFAULT NULL, gated_from_memory_id INTEGER REFERENCES memories(id), file_path TEXT, file_line INTEGER);
+, epoch_id INTEGER REFERENCES epochs(id), temporal_class TEXT NOT NULL DEFAULT 'medium', validation_agent_id TEXT REFERENCES agents(id), validated_at TEXT, trust_score REAL DEFAULT 1.0, derived_from_ids TEXT, retracted_at TEXT, retraction_reason TEXT, version INTEGER NOT NULL DEFAULT 1, memory_type TEXT NOT NULL DEFAULT 'episodic' CHECK(memory_type IN ('episodic','semantic')), protected INTEGER NOT NULL DEFAULT 0, salience_score REAL NOT NULL DEFAULT 0.0, gw_broadcast INTEGER NOT NULL DEFAULT 0, visibility TEXT NOT NULL DEFAULT 'public', read_acl TEXT, ewc_importance REAL NOT NULL DEFAULT 0.0, alpha REAL DEFAULT 1.0, beta  REAL DEFAULT 1.0, confidence_alpha REAL GENERATED ALWAYS AS (alpha) VIRTUAL, confidence_beta  REAL GENERATED ALWAYS AS (beta)  VIRTUAL, confidence_phase REAL NOT NULL DEFAULT 0.0, hilbert_projection BLOB DEFAULT NULL, coherence_syndrome TEXT DEFAULT NULL, decoherence_rate REAL DEFAULT NULL, gated_from_memory_id INTEGER REFERENCES memories(id), file_path TEXT, file_line INTEGER, write_tier TEXT NOT NULL DEFAULT 'full' CHECK(write_tier IN ('skip', 'construct', 'full')), indexed INTEGER NOT NULL DEFAULT 1, promoted_at TEXT DEFAULT NULL);
 
 CREATE INDEX idx_memories_agent ON memories(agent_id);
 
@@ -65,13 +65,19 @@ CREATE VIRTUAL TABLE memories_fts USING fts5(
     tokenize='porter unicode61'
 );
 
-CREATE TRIGGER memories_fts_insert AFTER INSERT ON memories BEGIN
+CREATE TRIGGER memories_fts_insert AFTER INSERT ON memories WHEN new.indexed = 1 BEGIN
     INSERT INTO memories_fts(rowid, content, category, tags) VALUES (new.id, new.content, new.category, new.tags);
 END;
 
-CREATE TRIGGER memories_fts_update AFTER UPDATE ON memories BEGIN
-    INSERT INTO memories_fts(memories_fts, rowid, content, category, tags) VALUES('delete', old.id, old.content, old.category, old.tags);
-    INSERT INTO memories_fts(rowid, content, category, tags) VALUES (new.id, new.content, new.category, new.tags);
+-- Split into two triggers so 0→1 promotion correctly adds to FTS without double-delete.
+CREATE TRIGGER memories_fts_update_delete AFTER UPDATE ON memories WHEN old.indexed = 1 BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content, category, tags)
+    VALUES ('delete', old.id, old.content, old.category, old.tags);
+END;
+
+CREATE TRIGGER memories_fts_update_insert AFTER UPDATE ON memories WHEN new.indexed = 1 BEGIN
+    INSERT INTO memories_fts(rowid, content, category, tags)
+    VALUES (new.id, new.content, new.category, new.tags);
 END;
 
 CREATE TRIGGER memories_fts_delete AFTER DELETE ON memories BEGIN
@@ -1633,3 +1639,19 @@ CREATE TABLE IF NOT EXISTS consolidation_forecasts (
 CREATE INDEX IF NOT EXISTS idx_forecasts_agent ON consolidation_forecasts(agent_id, predicted_demand_at);
 CREATE INDEX IF NOT EXISTS idx_forecasts_memory ON consolidation_forecasts(memory_id);
 CREATE INDEX IF NOT EXISTS idx_forecasts_fulfilled ON consolidation_forecasts(fulfilled_at);
+
+-- -------------------------------------------------------------------------
+-- D-MEM RPE routing (issue #31)
+-- memory_stats: per-(agent, category, scope) recall rate for long-term utility
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS memory_stats (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id TEXT NOT NULL,
+    category TEXT NOT NULL,
+    scope TEXT NOT NULL DEFAULT 'global',
+    avg_recall_rate REAL NOT NULL DEFAULT 0.5,
+    sample_count INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S','now')),
+    UNIQUE(agent_id, category, scope)
+);
+CREATE INDEX IF NOT EXISTS idx_memory_stats_agent ON memory_stats(agent_id, category, scope);

--- a/src/agentmemory/lib/write_decision.py
+++ b/src/agentmemory/lib/write_decision.py
@@ -7,6 +7,16 @@ if the write is novel enough to proceed. Returns (score, reason, components).
 score: float 0.0-1.0 (higher = more worthy)
 reason: str (empty string = approved, non-empty = rejection reason)
 components: dict of scoring breakdown
+
+D-MEM RPE routing (issue #31):
+  score < 0.3  → SKIP       (discard, no insert)
+  0.3 ≤ score < 0.7 → CONSTRUCT_ONLY  (write, no embedding/FTS)
+  score ≥ 0.7  → FULL_EVOLUTION  (write + embed + FTS)
+
+Long-term utility added as a scoring component:
+  - category_weight: identity/decision > lesson > convention > general
+  - scope_weight: agent-scoped > project-scoped > global
+  - recall_rate: historical avg recall_rate from memory_stats (if available)
 """
 
 import struct
@@ -32,14 +42,20 @@ def gate_write(
     db_vec,
     force: bool = False,
     arousal_gain: float = 1.0,
+    db_stats=None,
+    agent_id: str | None = None,
 ) -> tuple[float, str, dict]:
     """
     Evaluate write worthiness of a candidate memory.
 
+    Args:
+        db_stats: optional sqlite3 connection to the main brain DB (for memory_stats lookup)
+        agent_id: agent writing the memory (for memory_stats lookup)
+
     Returns:
         (score, reason, components)
         - score: 0.0-1.0 worthiness score
-        - reason: empty string if approved, rejection reason if rejected
+        - reason: empty string if approved, rejection reason if rejected (score < 0.3)
         - components: breakdown dict for diagnostics
     """
     if force:
@@ -77,15 +93,40 @@ def gate_write(
     novelty = 1.0 - max_similarity
     importance = confidence
     category_weights = {
-        "identity": 1.0, "convention": 0.9, "decision": 0.9,
-        "lesson": 0.8, "preference": 0.7, "project": 0.6,
-        "environment": 0.5, "user": 0.5, "integration": 0.5,
+        "identity": 1.0, "decision": 0.95, "lesson": 0.85,
+        "convention": 0.80, "preference": 0.70, "project": 0.65,
+        "environment": 0.50, "user": 0.50, "integration": 0.50,
     }
-    cat_weight = category_weights.get(category, 0.5)
+    cat_weight = category_weights.get(category, 0.50)
 
-    # Final worthiness score — precision-weighted by arousal (Free Energy Principle:
-    # arousal = global precision gain multiplier; McGaugh 2004 emotional consolidation)
-    base_score = novelty * 0.5 + importance * 0.3 + cat_weight * 0.2
+    # Scope specificity weight (D-MEM long-term utility component)
+    # Agent-scoped memories are more specific → higher utility
+    scope_weight = 0.50
+    if scope and scope.startswith("agent:"):
+        scope_weight = 1.0
+    elif scope and scope.startswith("project:"):
+        scope_weight = 0.75
+
+    # Historical recall rate from memory_stats (if DB available)
+    recall_rate = 0.50
+    if db_stats is not None and agent_id:
+        try:
+            row = db_stats.execute(
+                "SELECT avg_recall_rate FROM memory_stats "
+                "WHERE agent_id = ? AND category = ? AND scope = ?",
+                (agent_id, category, scope or "global"),
+            ).fetchone()
+            if row:
+                recall_rate = row[0] if isinstance(row, tuple) else row["avg_recall_rate"]
+        except Exception:
+            pass
+
+    # Long-term utility: geometric mean of category weight, scope weight, recall rate
+    long_term_utility = math.pow(cat_weight * scope_weight * recall_rate, 1.0 / 3.0)
+
+    # D-MEM RPE = semantic_surprise × long_term_utility
+    # Blend: novelty (surprise) 45% + long_term_utility 25% + importance 20% + scope_weight 10%
+    base_score = (novelty * 0.45) + (long_term_utility * 0.25) + (importance * 0.20) + (scope_weight * 0.10)
     gain = max(0.5, min(2.0, arousal_gain))  # clamp to [0.5, 2.0]
     score = min(1.0, base_score * gain)
 
@@ -95,13 +136,16 @@ def gate_write(
         "neighbor_count": neighbor_count,
         "importance": round(importance, 4),
         "category_weight": round(cat_weight, 4),
+        "scope_weight": round(scope_weight, 4),
+        "recall_rate": round(recall_rate, 4),
+        "long_term_utility": round(long_term_utility, 4),
         "arousal_gain": round(gain, 4),
         "base_score": round(base_score, 4),
         "score": round(score, 4),
     }
 
-    # Rejection threshold: score < 0.15 means near-duplicate with low importance
-    if score < 0.15:
-        return (round(score, 4), f"Low worthiness ({score:.3f}): near-duplicate content", components)
+    # SKIP threshold (D-MEM: RPE < 0.3 → discard)
+    if score < 0.3:
+        return (round(score, 4), f"Low worthiness ({score:.3f}): near-duplicate or low-utility content", components)
 
     return (round(score, 4), "", components)

--- a/src/agentmemory/mcp_server.py
+++ b/src/agentmemory/mcp_server.py
@@ -35,6 +35,7 @@ try:
         mcp_tools_agents,
         mcp_tools_allostatic,
         mcp_tools_analytics,
+        mcp_tools_dmem,
         mcp_tools_belief_merge,
         mcp_tools_beliefs,
         mcp_tools_consolidation,
@@ -64,6 +65,7 @@ try:
         mcp_tools_agents,
         mcp_tools_allostatic,
         mcp_tools_analytics,
+        mcp_tools_dmem,
         mcp_tools_belief_merge,
         mcp_tools_beliefs,
         mcp_tools_consolidation,
@@ -724,12 +726,25 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
         except Exception:
             pass
 
+    # D-MEM RPE three-tier routing (issue #31)
+    # Determine write_tier and indexed based on worthiness_score.
+    # None or ≥ 0.7 → FULL_EVOLUTION; 0.3–0.7 → CONSTRUCT_ONLY (no embed/FTS).
+    # < 0.3 is already rejected above (SKIP tier).
+    if worthiness_score is not None and not force and worthiness_score < 0.7:
+        write_tier = "construct"
+        do_index = 0
+    else:
+        write_tier = "full"
+        do_index = 1
+
     created_at = _now_ts()
     cur = db.execute(
         "INSERT INTO memories (agent_id, category, scope, content, confidence, tags, memory_type, "
-        "supersedes_id, alpha, trust_score, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+        "supersedes_id, alpha, trust_score, write_tier, indexed, created_at, updated_at) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
         (agent_id, category, scope, content, confidence, tags_json, memory_type,
-         supersedes_id, float(alpha_floor), source_trust, created_at, created_at)
+         supersedes_id, float(alpha_floor), source_trust, write_tier, do_index,
+         created_at, created_at)
     )
     mid = cur.lastrowid
 
@@ -741,25 +756,27 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
             pass
 
     log_access(db, agent_id, "write", "memories", mid)
-    # Embed on write — reuse blob computed above for the gate
+    # Embed on write — only for FULL_EVOLUTION tier
     embedded = False
-    try:
-        if not blob:
-            blob = _embed_safe(content)
-        if blob:
-            vdb = _get_vec_db()
-            if vdb:
-                vdb.execute("INSERT OR REPLACE INTO vec_memories(rowid, embedding) VALUES (?,?)", (mid, blob))
-                vdb.execute(
-                    "INSERT OR IGNORE INTO embeddings (source_table, source_id, model, dimensions, vector) VALUES (?,?,?,?,?)",
-                    ("memories", mid, EMBED_MODEL, 768, blob)
-                )
-                vdb.commit(); vdb.close()
-                embedded = True
-    except Exception:
-        pass
+    if do_index:
+        try:
+            if not blob:
+                blob = _embed_safe(content)
+            if blob:
+                vdb = _get_vec_db()
+                if vdb:
+                    vdb.execute("INSERT OR REPLACE INTO vec_memories(rowid, embedding) VALUES (?,?)", (mid, blob))
+                    vdb.execute(
+                        "INSERT OR IGNORE INTO embeddings (source_table, source_id, model, dimensions, vector) VALUES (?,?,?,?,?)",
+                        ("memories", mid, EMBED_MODEL, 768, blob)
+                    )
+                    vdb.commit(); vdb.close()
+                    embedded = True
+        except Exception:
+            pass
     db.commit(); db.close()
     result = {"ok": True, "memory_id": mid, "embedded": embedded, "worthiness_score": worthiness_score,
+              "write_tier": write_tier,
               "surprise_score": surprise, "surprise_method": surprise_method,
               "source": source, "trust_score": source_trust,
               "memory_type": memory_type}

--- a/src/agentmemory/mcp_tools_dmem.py
+++ b/src/agentmemory/mcp_tools_dmem.py
@@ -1,0 +1,252 @@
+"""brainctl MCP tools — D-MEM RPE routing (issue #31).
+
+D-MEM: three-tier write gate based on Reward Prediction Error routing.
+(Song & Xin, arXiv 2603.14597, 2025)
+
+RPE tiers:
+  SKIP           (score < 0.3)  — discarded, never written
+  CONSTRUCT_ONLY (0.3 ≤ score < 0.7) — written to DB, not embedded or FTS-indexed
+  FULL_EVOLUTION (score ≥ 0.7) — full pipeline: embed + FTS index + KG links
+
+Tools:
+  memory_promote  — promote a CONSTRUCT_ONLY memory to FULL_EVOLUTION (embed + index)
+  tier_stats      — show write-tier distribution for an agent
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from mcp.types import Tool
+
+DB_PATH = Path(os.environ.get("BRAIN_DB", str(Path.home() / "agentmemory" / "db" / "brain.db")))
+OLLAMA_EMBED_URL = os.environ.get("BRAINCTL_OLLAMA_URL", "http://localhost:11434/api/embed")
+EMBED_MODEL = os.environ.get("BRAINCTL_EMBED_MODEL", "nomic-embed-text")
+EMBED_DIMENSIONS = int(os.environ.get("BRAINCTL_EMBED_DIMENSIONS", "768"))
+
+_now = lambda: datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _db() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(DB_PATH), timeout=10)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA journal_mode = WAL")
+    return conn
+
+
+def _embed(text: str) -> bytes | None:
+    """Get embedding blob from Ollama. Returns None if unavailable."""
+    try:
+        import urllib.request, json as _json, struct as _struct
+        body = _json.dumps({"model": EMBED_MODEL, "input": text}).encode()
+        req = urllib.request.Request(OLLAMA_EMBED_URL, data=body,
+                                     headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = _json.loads(resp.read())
+        vec = data.get("embeddings", [None])[0]
+        if vec:
+            return _struct.pack(f"{len(vec)}f", *vec)
+    except Exception:
+        pass
+    return None
+
+
+def _get_vec_db() -> sqlite3.Connection | None:
+    """Open a connection with sqlite-vec extension loaded. Returns None if unavailable."""
+    try:
+        import sqlite_vec
+        conn = sqlite3.connect(str(DB_PATH), timeout=10)
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.enable_load_extension(False)
+        return conn
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# memory_promote
+# ---------------------------------------------------------------------------
+
+def tool_memory_promote(
+    memory_id: int | None = None,
+    agent_id: str = "mcp-client",
+    dry_run: bool = False,
+    **kw,
+) -> dict:
+    """Promote a CONSTRUCT_ONLY memory to FULL_EVOLUTION.
+
+    Embeds the memory content and adds it to FTS5 (memories_fts) and the
+    vector store (vec_memories). Sets write_tier='full', indexed=1, and
+    records promoted_at timestamp.
+
+    Safe to call on already-full memories (idempotent: reports already_full=True).
+    """
+    if not memory_id:
+        return {"ok": False, "error": "memory_id is required"}
+
+    db = _db()
+    try:
+        row = db.execute(
+            "SELECT id, content, write_tier, indexed FROM memories "
+            "WHERE id = ? AND agent_id = ?",
+            (memory_id, agent_id),
+        ).fetchone()
+        if not row:
+            return {"ok": False, "error": f"Memory {memory_id} not found for agent {agent_id}"}
+
+        if row["write_tier"] == "full" and row["indexed"] == 1:
+            return {"ok": True, "memory_id": memory_id, "already_full": True}
+
+        if dry_run:
+            return {"ok": True, "dry_run": True, "memory_id": memory_id,
+                    "write_tier": row["write_tier"], "indexed": row["indexed"]}
+
+        content = row["content"]
+        blob = _embed(content)
+        embedded = False
+
+        if blob:
+            vdb = _get_vec_db()
+            if vdb:
+                try:
+                    vdb.execute(
+                        "INSERT OR REPLACE INTO vec_memories(rowid, embedding) VALUES (?, ?)",
+                        (memory_id, blob),
+                    )
+                    vdb.execute(
+                        "INSERT OR IGNORE INTO embeddings "
+                        "(source_table, source_id, model, dimensions, vector) "
+                        "VALUES (?, ?, ?, ?, ?)",
+                        ("memories", memory_id, EMBED_MODEL, EMBED_DIMENSIONS, blob),
+                    )
+                    vdb.commit()
+                    embedded = True
+                finally:
+                    vdb.close()
+
+        # Promote: set write_tier='full', indexed=1, promoted_at=now
+        # The memories_fts_update_insert trigger fires when indexed becomes 1
+        db.execute(
+            "UPDATE memories SET write_tier = 'full', indexed = 1, promoted_at = ? WHERE id = ?",
+            (_now(), memory_id),
+        )
+        db.commit()
+
+        # Log a memory_promoted event
+        try:
+            db.execute(
+                "INSERT INTO events (agent_id, event_type, summary, created_at) "
+                "VALUES (?, 'memory_promoted', ?, ?)",
+                (agent_id, f"Promoted memory {memory_id} to FULL_EVOLUTION", _now()),
+            )
+            db.commit()
+        except Exception:
+            pass
+
+        return {
+            "ok": True,
+            "memory_id": memory_id,
+            "promoted": True,
+            "embedded": embedded,
+        }
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# tier_stats
+# ---------------------------------------------------------------------------
+
+def tool_tier_stats(
+    agent_id: str = "mcp-client",
+    **kw,
+) -> dict:
+    """Show write-tier distribution for an agent.
+
+    Returns count and percentage for each tier (full, construct, skip-equivalent),
+    plus average worthiness_score per tier if available.
+    """
+    db = _db()
+    try:
+        rows = db.execute(
+            "SELECT write_tier, COUNT(*) as cnt FROM memories "
+            "WHERE agent_id = ? AND retired_at IS NULL "
+            "GROUP BY write_tier",
+            (agent_id,),
+        ).fetchall()
+        if not rows:
+            return {"ok": True, "agent_id": agent_id, "total": 0, "tiers": {}}
+
+        total = sum(r["cnt"] for r in rows)
+        tiers = {}
+        for r in rows:
+            tiers[r["write_tier"]] = {
+                "count": r["cnt"],
+                "pct": round(100.0 * r["cnt"] / total, 1),
+            }
+
+        # Construct-only: unindexed memories that can be promoted
+        unindexed = db.execute(
+            "SELECT COUNT(*) as cnt FROM memories "
+            "WHERE agent_id = ? AND indexed = 0 AND retired_at IS NULL",
+            (agent_id,),
+        ).fetchone()["cnt"]
+
+        return {
+            "ok": True,
+            "agent_id": agent_id,
+            "total": total,
+            "tiers": tiers,
+            "unindexed_count": unindexed,
+        }
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# TOOLS list and DISPATCH
+# ---------------------------------------------------------------------------
+
+TOOLS = [
+    Tool(
+        name="memory_promote",
+        description=(
+            "Promote a CONSTRUCT_ONLY memory to FULL_EVOLUTION: embed content and add to FTS5 "
+            "and vector store. Sets write_tier='full', indexed=1. Idempotent — safe to call on "
+            "memories that are already full. Use dry_run=true to preview without writing."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "memory_id": {"type": "integer", "description": "ID of memory to promote"},
+                "dry_run": {"type": "boolean", "default": False},
+            },
+            "required": ["memory_id"],
+        },
+    ),
+    Tool(
+        name="tier_stats",
+        description=(
+            "Show write-tier distribution (full/construct) for an agent. "
+            "Reports count, percentage, and number of unindexed CONSTRUCT_ONLY memories "
+            "eligible for promotion."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {},
+        },
+    ),
+]
+
+DISPATCH: dict = {
+    "memory_promote": lambda **kw: tool_memory_promote(**kw),
+    "tier_stats": lambda **kw: tool_tier_stats(**kw),
+}

--- a/tests/test_mcp_tools_dmem.py
+++ b/tests/test_mcp_tools_dmem.py
@@ -1,0 +1,199 @@
+"""Tests for D-MEM RPE routing (issue #31): memory_promote and tier_stats."""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import agentmemory.mcp_tools_dmem as dmem
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def patch_db(tmp_path, monkeypatch):
+    """Each test gets an isolated Brain DB."""
+    from agentmemory.brain import Brain
+    db_file = tmp_path / "brain.db"
+    Brain(db_path=str(db_file), agent_id="test-agent")
+    monkeypatch.setattr(dmem, "DB_PATH", db_file)
+    return db_file
+
+
+def _insert_memory(db_file, agent_id="test-agent", write_tier="construct", indexed=0):
+    """Insert a memory directly and return its ID."""
+    conn = sqlite3.connect(str(db_file))
+    conn.execute("PRAGMA foreign_keys = ON")
+    # Ensure agent row exists
+    conn.execute(
+        "INSERT OR IGNORE INTO agents (id, display_name, agent_type) VALUES (?, ?, 'assistant')",
+        (agent_id, agent_id),
+    )
+    conn.execute(
+        "INSERT INTO memories (content, category, confidence, agent_id, write_tier, indexed, created_at) "
+        "VALUES ('test memory content', 'convention', 0.8, ?, ?, ?, '2026-01-01T00:00:00')",
+        (agent_id, write_tier, indexed),
+    )
+    conn.commit()
+    mid = conn.execute("SELECT id FROM memories ORDER BY id DESC LIMIT 1").fetchone()[0]
+    conn.close()
+    return mid
+
+
+# ---------------------------------------------------------------------------
+# memory_promote tests
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryPromote:
+    def test_requires_memory_id(self, patch_db):
+        result = dmem.tool_memory_promote(agent_id="test-agent")
+        assert result["ok"] is False
+        assert "memory_id" in result["error"]
+
+    def test_nonexistent_memory(self, patch_db):
+        result = dmem.tool_memory_promote(agent_id="test-agent", memory_id=99999)
+        assert result["ok"] is False
+        assert "not found" in result["error"]
+
+    def test_wrong_agent_id(self, patch_db):
+        mid = _insert_memory(patch_db)
+        result = dmem.tool_memory_promote(agent_id="other-agent", memory_id=mid)
+        assert result["ok"] is False
+
+    def test_dry_run_no_changes(self, patch_db):
+        mid = _insert_memory(patch_db, write_tier="construct", indexed=0)
+        result = dmem.tool_memory_promote(agent_id="test-agent", memory_id=mid, dry_run=True)
+        assert result["ok"] is True
+        assert result["dry_run"] is True
+        # No change in DB
+        conn = sqlite3.connect(str(patch_db))
+        row = conn.execute("SELECT indexed, write_tier FROM memories WHERE id = ?", (mid,)).fetchone()
+        conn.close()
+        assert row[0] == 0
+        assert row[1] == "construct"
+
+    def test_promotes_construct_memory(self, patch_db):
+        mid = _insert_memory(patch_db, write_tier="construct", indexed=0)
+        result = dmem.tool_memory_promote(agent_id="test-agent", memory_id=mid)
+        assert result["ok"] is True
+        assert result["promoted"] is True
+        # DB state updated
+        conn = sqlite3.connect(str(patch_db))
+        row = conn.execute("SELECT indexed, write_tier, promoted_at FROM memories WHERE id = ?", (mid,)).fetchone()
+        conn.close()
+        assert row[0] == 1
+        assert row[1] == "full"
+        assert row[2] is not None  # promoted_at set
+
+    def test_already_full_is_idempotent(self, patch_db):
+        mid = _insert_memory(patch_db, write_tier="full", indexed=1)
+        result = dmem.tool_memory_promote(agent_id="test-agent", memory_id=mid)
+        assert result["ok"] is True
+        assert result.get("already_full") is True
+
+    def test_fts_indexed_after_promote(self, patch_db):
+        """After promotion, the memory should appear in FTS MATCH search."""
+        # Use a unique token to avoid false positives from existing content
+        unique_token = "xq9plortzmem42"
+        conn = sqlite3.connect(str(patch_db))
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute(
+            "INSERT INTO memories (content, category, confidence, agent_id, write_tier, indexed, created_at) "
+            "VALUES (?, 'convention', 0.8, 'test-agent', 'construct', 0, '2026-01-01T00:00:00')",
+            (f"memory about {unique_token}",),
+        )
+        conn.commit()
+        mid = conn.execute("SELECT id FROM memories ORDER BY id DESC LIMIT 1").fetchone()[0]
+
+        # Verify NOT findable via FTS MATCH before promotion
+        before = conn.execute(
+            "SELECT COUNT(*) FROM memories_fts WHERE memories_fts MATCH ?", (unique_token,)
+        ).fetchone()[0]
+        conn.close()
+        assert before == 0, "Unindexed memory should not appear in FTS MATCH"
+
+        dmem.tool_memory_promote(agent_id="test-agent", memory_id=mid)
+
+        conn = sqlite3.connect(str(patch_db))
+        after = conn.execute(
+            "SELECT COUNT(*) FROM memories_fts WHERE memories_fts MATCH ?", (unique_token,)
+        ).fetchone()[0]
+        conn.close()
+        assert after == 1, "Promoted memory should appear in FTS MATCH"
+
+    def test_promotion_event_logged(self, patch_db):
+        mid = _insert_memory(patch_db, write_tier="construct", indexed=0)
+        dmem.tool_memory_promote(agent_id="test-agent", memory_id=mid)
+        conn = sqlite3.connect(str(patch_db))
+        evt = conn.execute(
+            "SELECT event_type FROM events WHERE event_type = 'memory_promoted' LIMIT 1"
+        ).fetchone()
+        conn.close()
+        assert evt is not None
+
+
+# ---------------------------------------------------------------------------
+# tier_stats tests
+# ---------------------------------------------------------------------------
+
+
+class TestTierStats:
+    def test_empty_db_returns_ok(self, patch_db):
+        result = dmem.tool_tier_stats(agent_id="test-agent")
+        assert result["ok"] is True
+        assert result["total"] == 0
+        assert result["tiers"] == {}
+
+    def test_counts_tiers(self, patch_db):
+        # Insert 2 full, 3 construct
+        for _ in range(2):
+            _insert_memory(patch_db, write_tier="full", indexed=1)
+        for _ in range(3):
+            _insert_memory(patch_db, write_tier="construct", indexed=0)
+        result = dmem.tool_tier_stats(agent_id="test-agent")
+        assert result["ok"] is True
+        assert result["total"] == 5
+        assert result["tiers"]["full"]["count"] == 2
+        assert result["tiers"]["construct"]["count"] == 3
+
+    def test_unindexed_count_matches_construct(self, patch_db):
+        for _ in range(3):
+            _insert_memory(patch_db, write_tier="construct", indexed=0)
+        _insert_memory(patch_db, write_tier="full", indexed=1)
+        result = dmem.tool_tier_stats(agent_id="test-agent")
+        assert result["unindexed_count"] == 3
+
+    def test_percentages_sum_to_100(self, patch_db):
+        _insert_memory(patch_db, write_tier="full", indexed=1)
+        _insert_memory(patch_db, write_tier="construct", indexed=0)
+        result = dmem.tool_tier_stats(agent_id="test-agent")
+        total_pct = sum(t["pct"] for t in result["tiers"].values())
+        assert abs(total_pct - 100.0) < 0.2  # floating-point tolerance
+
+    def test_excludes_retired_memories(self, patch_db):
+        mid = _insert_memory(patch_db, write_tier="full", indexed=1)
+        # Retire the memory
+        conn = sqlite3.connect(str(patch_db))
+        conn.execute("UPDATE memories SET retired_at = '2026-01-01T00:00:00' WHERE id = ?", (mid,))
+        conn.commit()
+        conn.close()
+        result = dmem.tool_tier_stats(agent_id="test-agent")
+        assert result["total"] == 0
+
+    def test_agent_isolation(self, patch_db):
+        """Stats for one agent don't include another's memories."""
+        _insert_memory(patch_db, agent_id="test-agent", write_tier="full", indexed=1)
+        _insert_memory(patch_db, agent_id="other-agent", write_tier="construct", indexed=0)
+        result = dmem.tool_tier_stats(agent_id="test-agent")
+        assert result["total"] == 1
+        assert "construct" not in result["tiers"]


### PR DESCRIPTION
## Summary

- Implements D-MEM (Song & Xin, arXiv 2603.14597) three-tier write routing based on W(m) score
- Three tiers: **SKIP** (< 0.3, discard), **CONSTRUCT_ONLY** (0.3–0.7, write without embed/FTS), **FULL_EVOLUTION** (≥ 0.7, full pipeline)
- Adds `write_tier`, `indexed`, `promoted_at` columns to memories (migration 031)
- Updates FTS5 triggers to only index when `indexed = 1` (WHEN clause + split update triggers for 0→1 promotion)
- Adds `memory_stats` table for long-term utility (category recall rate)
- Updates `write_decision.py` to include scope weight + recall rate as long-term utility component
- New tools: `memory_promote` (promote CONSTRUCT_ONLY → FULL_EVOLUTION), `tier_stats`
- MCP tool count: 186 → 188

## How it works

```
W(m) gate score < 0.3  → SKIP       — discarded, no insert
             0.3–0.7  → CONSTRUCT  — INSERT with indexed=0, no embed/FTS (O(1))
             ≥ 0.7    → FULL       — INSERT + embed + FTS index + KG links (O(N))
```

CONSTRUCT_ONLY memories can be promoted later via `memory_promote`, which embeds
the content and triggers the FTS update via the `indexed 0→1` trigger.

## Test plan

- [x] `tests/test_mcp_tools_dmem.py` — 14 tests: promote (idempotent, dry_run, FTS indexing verified with MATCH query, event logged, wrong-agent rejected), tier_stats (counts, percentages, unindexed count, agent isolation, retired exclusion)
- [x] Full suite: 1182 tests passing

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)