### PR TITLE
fix: D-MEM consistency — CLI three-tier routing + memory_stats population

### DIFF
--- a/bin/brainctl-mcp
+++ b/bin/brainctl-mcp
@@ -417,6 +417,8 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
                         scope=scope,
                         db_vec=vdb_gate,
                         force=False,
+                        db_stats=db,
+                        agent_id=agent_id,
                     )
                 finally:
                     vdb_gate.close()

--- a/src/agentmemory/_impl.py
+++ b/src/agentmemory/_impl.py
@@ -1105,6 +1105,8 @@ def cmd_memory_add(args):
                         db_vec=db_vec_gate,
                         force=False,
                         arousal_gain=_arousal_boost,
+                        db_stats=db,
+                        agent_id=args.agent,
                     )
                 finally:
                     db_vec_gate.close()
@@ -1243,15 +1245,27 @@ def cmd_memory_add(args):
         except Exception as exc:
             logger.debug("Cap check failed (non-fatal): %s", exc)
 
+    # D-MEM RPE three-tier routing (issue #31)
+    # score < 0.3 → SKIP (already rejected above)
+    # 0.3 ≤ score < 0.7 → CONSTRUCT_ONLY (no embed/FTS)
+    # score ≥ 0.7 or None → FULL_EVOLUTION (embed + FTS)
+    if worthiness_score is not None and not force_write and worthiness_score < 0.7:
+        write_tier = "construct"
+        do_index = 0
+    else:
+        write_tier = "full"
+        do_index = 1
+
     file_path = getattr(args, "file_path", None)
     file_line = getattr(args, "file_line", None)
     cursor = db.execute(
         "INSERT INTO memories (agent_id, category, scope, content, confidence, tags, source_event_id, "
-        "memory_type, supersedes_id, alpha, file_path, file_line, created_at, updated_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "memory_type, supersedes_id, alpha, file_path, file_line, write_tier, indexed, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (args.agent, args.category, args.scope or "global", args.content,
          effective_confidence, tags_json, args.source_event, memory_type,
-         supersedes_id, float(alpha_floor), file_path, file_line, _now_ts(), _now_ts())
+         supersedes_id, float(alpha_floor), file_path, file_line,
+         write_tier, do_index, _now_ts(), _now_ts())
     )
     memory_id = cursor.lastrowid
 
@@ -1342,34 +1356,36 @@ def cmd_memory_add(args):
         except Exception:
             pass  # non-fatal
 
-    # Sync embedding on write — keep vec_memories in lock-step
+    # Sync embedding on write — only for FULL_EVOLUTION tier (indexed=1)
     # blob was already computed above for the gate; reuse it here.
     embedded = False
-    try:
-        if not blob:
-            blob = _embed_query_safe(args.content)
-        if blob:
-            db_vec = _try_get_db_with_vec()
-            if db_vec:
-                db_vec.execute(
-                    "INSERT OR REPLACE INTO vec_memories(rowid, embedding) VALUES (?, ?)",
-                    (memory_id, blob)
-                )
-                db_vec.execute(
-                    "INSERT OR IGNORE INTO embeddings (source_table, source_id, model, dimensions, vector) VALUES (?,?,?,?,?)",
-                    ("memories", memory_id, EMBED_MODEL, EMBED_DIMENSIONS, blob)
-                )
-                db_vec.commit()
-                db_vec.close()
-                embedded = True
-    except Exception:
-        pass  # non-fatal: backfill cron handles coverage gaps
+    if do_index:
+        try:
+            if not blob:
+                blob = _embed_query_safe(args.content)
+            if blob:
+                db_vec = _try_get_db_with_vec()
+                if db_vec:
+                    db_vec.execute(
+                        "INSERT OR REPLACE INTO vec_memories(rowid, embedding) VALUES (?, ?)",
+                        (memory_id, blob)
+                    )
+                    db_vec.execute(
+                        "INSERT OR IGNORE INTO embeddings (source_table, source_id, model, dimensions, vector) VALUES (?,?,?,?,?)",
+                        ("memories", memory_id, EMBED_MODEL, EMBED_DIMENSIONS, blob)
+                    )
+                    db_vec.commit()
+                    db_vec.close()
+                    embedded = True
+        except Exception:
+            pass  # non-fatal: backfill cron handles coverage gaps
 
     out = {
         "ok": True,
         "memory_id": memory_id,
         "reflexion": getattr(args, "reflexion", False),
         "embedded": embedded,
+        "write_tier": write_tier,
         "effective_confidence": effective_confidence,
         "source_weight": round(source_weight_applied, 4),
         "conflict_logged": conflict_logged,

--- a/src/agentmemory/lib/write_decision.py
+++ b/src/agentmemory/lib/write_decision.py
@@ -108,16 +108,43 @@ def gate_write(
         scope_weight = 0.75
 
     # Historical recall rate from memory_stats (if DB available)
+    # Falls back to computing from live data and caching the result.
     recall_rate = 0.50
     if db_stats is not None and agent_id:
         try:
             row = db_stats.execute(
-                "SELECT avg_recall_rate FROM memory_stats "
+                "SELECT avg_recall_rate, sample_count FROM memory_stats "
                 "WHERE agent_id = ? AND category = ? AND scope = ?",
                 (agent_id, category, scope or "global"),
             ).fetchone()
             if row:
-                recall_rate = row[0] if isinstance(row, tuple) else row["avg_recall_rate"]
+                rr = row[0] if isinstance(row, tuple) else row["avg_recall_rate"]
+                recall_rate = rr if rr is not None else 0.50
+            else:
+                # No cached stats — compute from live data and seed the cache
+                live = db_stats.execute(
+                    "SELECT COUNT(*) as cnt, "
+                    "AVG(CASE WHEN recalled_count > 0 THEN 1.0 ELSE 0.0 END) as rate "
+                    "FROM memories WHERE agent_id = ? AND category = ? "
+                    "AND scope = ? AND retired_at IS NULL",
+                    (agent_id, category, scope or "global"),
+                ).fetchone()
+                if live:
+                    cnt = live[0] if isinstance(live, tuple) else live["cnt"]
+                    rate = live[1] if isinstance(live, tuple) else live["rate"]
+                    if cnt and cnt > 0 and rate is not None:
+                        recall_rate = rate
+                        try:
+                            db_stats.execute(
+                                "INSERT OR REPLACE INTO memory_stats "
+                                "(agent_id, category, scope, avg_recall_rate, sample_count) "
+                                "VALUES (?, ?, ?, ?, ?)",
+                                (agent_id, category, scope or "global",
+                                 round(recall_rate, 4), cnt),
+                            )
+                            db_stats.commit()
+                        except Exception:
+                            pass  # table may not exist yet
         except Exception:
             pass
 

--- a/src/agentmemory/mcp_server.py
+++ b/src/agentmemory/mcp_server.py
@@ -614,6 +614,8 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
                         db_vec=vdb_gate,
                         force=False,
                         arousal_gain=_arousal_gain,
+                        db_stats=db,
+                        agent_id=agent_id,
                     )
                 finally:
                     vdb_gate.close()


### PR DESCRIPTION
## Summary

Follow-up to PR #54 (D-MEM RPE routing). Addresses three gaps identified in self-review:

- **`_impl.py` now uses three-tier routing** — `brainctl memory add` via CLI was still using the old binary gate. Now routes through SKIP/CONSTRUCT_ONLY/FULL_EVOLUTION like `mcp_server.py` and `bin/brainctl-mcp`
- **`memory_stats` gets populated lazily** — `write_decision.py` now computes recall rate from live data when no cached entry exists, seeds `memory_stats` for future lookups. Eliminates the permanent 0.5 default
- **All callers pass `db_stats` + `agent_id`** to `gate_write()` so long-term utility is actually computed instead of using defaults

## Test plan

- [x] Full suite: 1226 tests passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)