### PR TITLE
feat: agent onboarding — thick Brain class, examples, guide, MCP decision tree

### DIFF
--- a/MCP_SERVER.md
+++ b/MCP_SERVER.md
@@ -98,6 +98,86 @@ docker run -v ~/.agentmemory:/data -e BRAIN_DB=/data/brain.db ghcr.io/yourorg/br
 | `zoom_in` | Given a summary memory, return its constituent child memories |
 | `temporal_map` | Count breakdown of memories at each temporal level for an agent |
 
+## Which Tools Do I Need?
+
+192 tools is overwhelming. Most agents need ~15 on a daily basis. Here's how to find what you need.
+
+### Tier 1: Essential (daily use)
+
+**Store information:**
+- Durable fact/lesson/convention: `memory_add` (enforces W(m) write gate)
+- What just happened: `event_add` (timestamped, no gate)
+- Why a choice was made: `decision_add` (with rationale)
+- Working state for next session: `handoff_add`
+
+**Find information:**
+- Everything about a topic: `search` (memories + events + entities)
+- Just memories: `memory_search` (supports category, scope, pagerank_boost)
+- Just events: `event_search` (supports event_type, project)
+- A specific entity: `entity_get`
+- Entities matching a query: `entity_search`
+
+**Track entities:**
+- New entity: `entity_create`
+- New fact about entity: `entity_observe`
+- Link two entities: `entity_relate`
+
+**Session continuity:**
+- Set a future reminder: `trigger_create`
+- Check reminders: `trigger_check`
+- Resume prior work: `handoff_latest` / `handoff_consume`
+
+**Health:**
+- Database overview: `stats`
+- Schema integrity: `validate`
+- Quality lint: `lint`
+
+### Tier 2: Advanced (weekly/as-needed)
+
+| Category | Tools | When to use |
+|----------|-------|-------------|
+| Consolidation | `consolidation_run`, `replay_boost`, `replay_queue` | Memory maintenance |
+| Reconsolidation | `reconsolidation_check`, `reconsolidate` | Lability window mechanics |
+| Beliefs & Conflicts | `resolve_conflict`, `belief_collapse` | When memories contradict |
+| Temporal Abstraction | `abstract_summarize`, `zoom_out`, `zoom_in`, `temporal_map` | Hierarchical summarization |
+| Allostatic Scheduling | `consolidation_schedule`, `allostatic_prime`, `demand_forecast` | Predictive memory pre-loading |
+| Immunity | `quarantine_list`, `quarantine_review`, `quarantine_purge` | Poisoned memory handling |
+| D-MEM | `memory_promote`, `tier_stats` | Write-tier management |
+| Metacognition | `memory_calibration`, `attention_snapshot`, `free_energy_check` | Self-monitoring |
+| Affect | `affect_classify`, `affect_log`, `affect_check`, `affect_monitor` | Emotional state tracking |
+
+### Tier 3: Specialist (~150 tools)
+
+The remaining tools cover specialized subsystems: Theory of Mind, Trust scoring, Neuromodulation, MEB (Memory Event Buffer), Expertise routing, Federation, Policy memory, Reasoning chains, Reflexion loops, Workspace management, World models, Analytics, Telemetry, and Usage tracking. These are documented in the individual `mcp_tools_*.py` source modules.
+
+### Decision Tree
+
+```
+What do you need?
+|
++-- Store something?
+|   +-- Durable fact ----------> memory_add
+|   +-- What just happened ----> event_add
+|   +-- Why a choice was made -> decision_add
+|   +-- State for next session > handoff_add
+|
++-- Find something?
+|   +-- Broad topic search ----> search
+|   +-- Memories only ---------> memory_search
+|   +-- Events only -----------> event_search
+|   +-- Entity by name --------> entity_get
+|
++-- Track an entity?
+|   +-- New entity ------------> entity_create
+|   +-- New fact about it -----> entity_observe
+|   +-- Link two entities -----> entity_relate
+|
++-- Set a reminder? -----------> trigger_create
++-- Check reminders? ----------> trigger_check
++-- Resume prior work? --------> handoff_latest
++-- Check system health? ------> stats / health / lint
+```
+
 ## Environment Variables
 
 | Variable | Default | Description |

--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -1,0 +1,253 @@
+# Agent Onboarding Guide
+
+A step-by-step guide for AI agents integrating with brainctl. Written by an agent, for agents.
+
+## Prerequisites
+
+- Python 3.11+
+- `pip install brainctl` (core, zero dependencies beyond stdlib)
+- Optional: `pip install brainctl[vec]` for vector search (requires Ollama running)
+- Optional: `pip install brainctl[mcp]` for MCP server integration
+- No API keys. No server. No LLM calls. Just a SQLite file.
+
+## 5-Minute Quickstart
+
+### Python API (simplest path)
+
+```python
+from agentmemory import Brain
+
+brain = Brain()                                    # creates ~/agentmemory/db/brain.db
+brain = Brain("/path/to/brain.db", agent_id="my-agent")  # custom path + agent ID
+
+# Store knowledge
+brain.remember("API rate-limits at 100 req/15s", category="integration", confidence=0.9)
+
+# Search (FTS5 full-text search with stemming)
+results = brain.search("rate limit")
+
+# Build knowledge graph
+brain.entity("AuthService", "service", observations=["JWT", "bcrypt cost=12"])
+brain.relate("api-v2", "depends_on", "AuthService")
+
+# Log events and decisions
+brain.log("Deployed v2.0 to staging", event_type="result", project="api-v2")
+brain.decide("Use Retry-After for backoff", "Server controls timing", project="api-v2")
+
+# Session continuity
+brain.handoff("finish integration", "auth done", "rate limiting", "add retry logic")
+packet = brain.resume()  # fetches + consumes latest handoff
+
+# Prospective memory
+brain.trigger("deploy fails", "deploy,failure,502", "check rollback and page oncall")
+
+# Diagnostics
+brain.doctor()  # {'healthy': True, 'issues': [], 'active_memories': 5, ...}
+```
+
+### CLI (full features, production use)
+
+```bash
+brainctl init
+brainctl -a my-agent memory add "API rate-limits at 100 req/15s" -c integration
+brainctl -a my-agent search "rate limit"
+brainctl -a my-agent entity create "AuthService" -t service -o "JWT" -o "bcrypt cost=12"
+brainctl -a my-agent event add "Deployed v2.0" -t result -p api-v2
+brainctl stats
+```
+
+The CLI enforces the W(m) write gate (surprise scoring) and has the full feature set. The Python API is raw access — faster to use, but no write gate.
+
+## Core Concepts
+
+### Memories
+
+Durable facts stored with a category that determines their natural decay rate.
+
+| Category | Half-life | Use for |
+|----------|-----------|---------|
+| `identity` | permanent | Who the agent is, core values |
+| `convention` | long | Team norms, coding standards |
+| `decision` | long | Choices made and why |
+| `lesson` | long | Learnings from failures |
+| `preference` | medium | User/agent preferences |
+| `project` | medium | Project-specific knowledge |
+| `integration` | medium | API behavior, system interfaces |
+| `environment` | short | Infrastructure, deployment state |
+| `user` | medium | User-specific context |
+
+### Events
+
+Timestamped, append-only logs of what happened. Types: `observation`, `result`, `decision`, `error`, `handoff`, `task_update`, `artifact`, `session_start`, `session_end`, `warning`.
+
+Events are for *actions*. Memories are for *durable facts*. Don't store "I ran npm install" as a memory — log it as an event.
+
+### Entities
+
+Typed nodes in the knowledge graph: `person`, `project`, `tool`, `concept`, `organization`, `location`, `service`, `agent`, `document`.
+
+Entities carry **observations** (atomic facts) and **properties** (structured JSON). Link them with `relate()` to build a queryable knowledge graph.
+
+### Decisions
+
+Title + rationale. The "why" record. Critical for preventing future agents from contradicting prior choices without understanding the reasoning.
+
+## The Write Gate (W(m))
+
+The CLI and MCP enforce a worthiness gate before accepting memories:
+
+```
+W(m) = surprise x importance x (1 - redundancy) x arousal_boost
+```
+
+- **Score < 0.3**: SKIP — rejected, not written
+- **Score 0.3-0.7**: CONSTRUCT_ONLY — written but not FTS/vector indexed (lightweight)
+- **Score >= 0.7**: FULL_EVOLUTION — full pipeline (embed, index, KG links)
+
+The Python API (`brain.remember()`) bypasses this gate. Use the CLI or MCP for production writes where deduplication matters.
+
+**What passes**: Novel, specific facts with clear signal. *"API rate-limits at 100 req/15s with Retry-After header"*
+
+**What gets rejected**: Near-duplicates, trivial observations. *"I ran the tests"*, *"the build passed"*
+
+Bypass with `--force` (CLI) or `force=true` (MCP) when you know the gate is wrong.
+
+## Search & Retrieval
+
+Three modes, in order of richness:
+
+| Mode | Interface | How it works |
+|------|-----------|-------------|
+| **FTS5** | Python API `search()`, CLI, MCP | Porter stemming, ranked by relevance |
+| **Vector** | Python API `vsearch()`, MCP `search(vector=true)` | Cosine similarity via Ollama embeddings |
+| **Cross-table** | MCP `search` tool | Searches memories + events + entities together |
+
+For broad "what do I know about X?" queries, use the MCP `search` tool. For specific memory lookup, use `memory_search` with category/scope filters.
+
+## Session Continuity
+
+### The Orient-Work-Record Loop
+
+Every session should follow this pattern (from COGNITIVE_PROTOCOL.md):
+
+1. **Orient**: Search before working. Check existing memories, events, decisions.
+2. **Work**: Save discoveries immediately with the right category.
+3. **Record**: Log completion events with actual results. Record decisions with rationale.
+
+### Handoff Packets
+
+Use handoffs to preserve working context across sessions:
+
+```python
+# End of session — save state
+brain.handoff(
+    goal="Finish API integration",
+    current_state="Auth complete, rate limiting documented",
+    open_loops="Retry logic not implemented, load test not started",
+    next_step="Implement backoff using Retry-After header",
+    project="api-v2",
+)
+
+# Start of next session — resume
+packet = brain.resume(project="api-v2")
+if packet:
+    print(f"Resuming: {packet['goal']}")
+    print(f"Next: {packet['next_step']}")
+```
+
+### Triggers (Prospective Memory)
+
+Set conditions that fire when matched in future queries:
+
+```python
+brain.trigger("deploy failure", "deploy,failure,rollback,502", "check rollback procedure")
+
+# Later, when processing events:
+matches = brain.check_triggers("staging deploy returned 502")
+# [{'action': 'check rollback procedure', 'priority': 'critical', ...}]
+```
+
+## Health & Diagnostics
+
+### Quick check
+
+```python
+dx = brain.doctor()
+# {'healthy': True, 'issues': [], 'active_memories': 42, 'fts5_available': True,
+#  'vec_available': True, 'db_size_mb': 2.3, 'db_path': '/path/to/brain.db'}
+```
+
+### Full health (MCP/CLI)
+
+| Tool | What it checks |
+|------|---------------|
+| `validate` | Schema integrity, missing tables, FK violations, orphans |
+| `health` | SLO dashboard: coverage, freshness, precision, diversity |
+| `lint` | Quality: low-confidence memories, dead weight, duplicates |
+| `backup` | Timestamped backup to `~/agentmemory/backups/` |
+
+### Maintenance
+
+Schedule periodic consolidation (decay, compress, promote):
+
+```bash
+# Every 4 hours via cron:
+0 */4 * * * BRAIN_DB=~/agentmemory/db/brain.db brainctl-consolidate sweep
+```
+
+## Common Patterns
+
+### Autonomous Agent (long-running, self-directed)
+
+- Orient at session start with `search` + `event tail`
+- Store discoveries as memories with correct categories
+- Log all actions as events
+- Create handoff before shutdown
+- Schedule consolidation via cron
+- Use triggers for important future conditions
+
+### Pipeline Agent (task-based)
+
+- On task checkout: search for relevant context
+- After task: log event with result/error type
+- For durable learnings: remember with `category=lesson`
+- No handoffs needed — tasks are the continuity unit
+
+### Assistant Agent (interactive, user-facing)
+
+- Remember user preferences (`category=preference`)
+- Track entities mentioned by user
+- Use triggers for follow-ups
+- Log session start/end for audit trail
+
+## Anti-patterns
+
+1. **Skipping orientation** — You WILL redo work or violate prior decisions. Always search first.
+2. **Saving trivial state as memories** — "I ran npm install" is an event, not a memory.
+3. **Not logging after work** — Future agents fly blind without result events.
+4. **Wrong category** — Match the half-life to the volatility of the fact.
+5. **Using `agent_id="unknown"`** — Attribution matters for trust scoring and audit.
+6. **Task progress as memories** — Use events or your issue tracker.
+7. **Ignoring write gate rejection** — If the gate rejects, the fact is probably redundant. Check existing memories.
+8. **Never running consolidation** — Memory store grows unbounded without periodic sweeps.
+9. **Storing secrets** — brain.db is a plain SQLite file. Never store API keys, tokens, or credentials.
+
+## Cheat Sheet
+
+| Task | Python API | CLI | MCP Tool |
+|------|-----------|-----|----------|
+| Store a fact | `brain.remember(text, category)` | `brainctl memory add "..." -c cat` | `memory_add` |
+| Search memories | `brain.search(query)` | `brainctl search "..."` | `search` |
+| Vector search | `brain.vsearch(query)` | `brainctl vsearch "..."` | `search(vector=true)` |
+| Create entity | `brain.entity(name, type)` | `brainctl entity create "..." -t type` | `entity_create` |
+| Link entities | `brain.relate(a, rel, b)` | `brainctl entity relate a rel b` | `entity_relate` |
+| Log event | `brain.log(summary, type)` | `brainctl event add "..." -t type` | `event_add` |
+| Record decision | `brain.decide(title, why)` | `brainctl decision add ...` | `decision_add` |
+| Create handoff | `brain.handoff(goal, ...)` | `brainctl handoff add ...` | `handoff_add` |
+| Resume handoff | `brain.resume()` | `brainctl handoff latest` | `handoff_latest` |
+| Set trigger | `brain.trigger(cond, kw, act)` | `brainctl trigger create ...` | `trigger_create` |
+| Check triggers | `brain.check_triggers(q)` | `brainctl trigger check "..."` | `trigger_check` |
+| Diagnostics | `brain.doctor()` | `brainctl health` | `health` |
+| Consolidate | `brain.consolidate()` | `brainctl-consolidate sweep` | `consolidation_run` |
+| Affect classify | `brain.affect(text)` | `brainctl affect classify "..."` | `affect_classify` |
+| View stats | `brain.stats()` | `brainctl stats` | `stats` |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,25 @@
+# Examples
+
+Runnable scripts demonstrating the brainctl Python API.
+
+| Script | What it shows |
+|--------|---------------|
+| `quickstart.py` | Minimum viable agent — remember, search, entities, events in 30 lines |
+| `agent_lifecycle.py` | Full session: bootstrap, orient, work, record, handoff, resume |
+| `multi_agent.py` | Two agents sharing knowledge through a single brain.db |
+
+## Running
+
+```bash
+python examples/quickstart.py
+python examples/agent_lifecycle.py
+python examples/multi_agent.py
+```
+
+All examples use temp databases and won't touch your real `brain.db`.
+
+## Next steps
+
+- [Agent Onboarding Guide](../docs/AGENT_ONBOARDING.md) — full walkthrough
+- [Cognitive Protocol](../COGNITIVE_PROTOCOL.md) — the Orient-Work-Record pattern
+- [MCP Server](../MCP_SERVER.md) — 192 tools for advanced features

--- a/examples/agent_lifecycle.py
+++ b/examples/agent_lifecycle.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""brainctl agent lifecycle — bootstrap, orient, work, record, handoff.
+
+Demonstrates the Orient -> Work -> Record pattern from COGNITIVE_PROTOCOL.md
+with session bookending and handoff for continuity.
+
+Run:  python examples/agent_lifecycle.py
+"""
+import os, tempfile
+from agentmemory import Brain
+
+db_path = os.path.join(tempfile.gettempdir(), "lifecycle_brain.db")
+brain = Brain(db_path, agent_id="lifecycle-demo")
+
+# ── PHASE 1: BOOTSTRAP ──────────────────────────────────────────────
+print("=== Phase 1: Bootstrap ===")
+brain.log("Session started", event_type="session_start", project="api-v2")
+brain.entity("api-v2", "project", observations=["REST API", "Python 3.12", "PostgreSQL"])
+brain.entity("lifecycle-demo", "agent", observations=["Integration specialist"])
+brain.relate("lifecycle-demo", "works_on", "api-v2")
+print("  Registered agent and project entities")
+
+# Set a trigger for future sessions
+brain.trigger(
+    condition="deployment failure detected",
+    keywords="deploy,failure,rollback,502",
+    action="Check rollback procedure and notify oncall",
+    priority="critical",
+)
+print("  Set prospective memory trigger for deploy failures")
+
+# ── PHASE 2: ORIENT ─────────────────────────────────────────────────
+print("\n=== Phase 2: Orient ===")
+existing = brain.search("api-v2 conventions")
+print(f"  Found {len(existing)} existing memories about api-v2")
+stats = brain.stats()
+print(f"  Brain state: {stats['active_memories']} active memories, {stats['events']} events")
+
+# ── PHASE 3: WORK ───────────────────────────────────────────────────
+print("\n=== Phase 3: Work ===")
+
+# Discover things while working
+brain.remember("API rate-limits at 100 req/15s with Retry-After header", category="integration", confidence=0.9)
+brain.remember("Team convention: all timestamps must be UTC ISO 8601", category="convention")
+brain.remember("PostgreSQL connection pool max=20, timeout=30s", category="environment")
+print("  Stored 3 discoveries as memories")
+
+# Record a decision with rationale
+brain.decide(
+    "Use Retry-After header for rate limit backoff",
+    "More reliable than fixed exponential backoff — server controls the timing",
+    project="api-v2",
+)
+print("  Recorded decision: use Retry-After header")
+
+# Build knowledge graph
+brain.entity("RateLimitAPI", "service", observations=["100 req/15s", "Retry-After header", "us-east-1"])
+brain.relate("api-v2", "depends_on", "RateLimitAPI")
+print("  Linked api-v2 -> depends_on -> RateLimitAPI")
+
+# Check if any triggers match what we're seeing
+matches = brain.check_triggers("the staging deploy returned 502 errors")
+if matches:
+    print(f"  TRIGGER FIRED: {matches[0]['action']}")
+
+# ── PHASE 4: RECORD ─────────────────────────────────────────────────
+print("\n=== Phase 4: Record ===")
+brain.log("Completed API integration analysis — rate limiting documented",
+          event_type="result", project="api-v2", importance=0.8)
+brain.affect_log("Satisfied with the rate limit discovery — clear path forward")
+brain.log("Session ended", event_type="session_end", project="api-v2")
+print("  Logged result event, affect state, and session end")
+
+# ── PHASE 5: HANDOFF ────────────────────────────────────────────────
+print("\n=== Phase 5: Handoff ===")
+hid = brain.handoff(
+    goal="Finish api-v2 integration with rate-limited external service",
+    current_state="Rate limiting behavior documented. Auth module complete. Connection pool configured.",
+    open_loops="Retry logic not yet implemented. Load testing not started.",
+    next_step="Implement exponential backoff using Retry-After header. Then run load test at 80% capacity.",
+    project="api-v2",
+    title="API v2 Integration Sprint",
+)
+print(f"  Created handoff packet #{hid}")
+
+# Simulate a new session resuming from the handoff
+print("\n=== New Session: Resume ===")
+brain2 = Brain(db_path, agent_id="lifecycle-demo")
+packet = brain2.resume(project="api-v2")
+if packet:
+    print(f"  Resumed: {packet['goal']}")
+    print(f"  State: {packet['current_state'][:80]}...")
+    print(f"  Next: {packet['next_step'][:80]}...")
+else:
+    print("  No pending handoff found")
+
+# Final stats
+print(f"\nFinal stats: {brain2.stats()}")
+dx = brain2.doctor()
+print(f"Health: {'healthy' if dx['healthy'] else 'ISSUES: ' + str(dx['issues'])}")

--- a/examples/multi_agent.py
+++ b/examples/multi_agent.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""brainctl multi-agent — two agents sharing knowledge through a single brain.db.
+
+Demonstrates cross-agent knowledge discovery: one agent stores facts,
+another discovers them via search. Both read from the same database.
+
+Run:  python examples/multi_agent.py
+"""
+import os, tempfile
+from agentmemory import Brain
+
+db_path = os.path.join(tempfile.gettempdir(), "multi_agent_brain.db")
+
+# Two Brain instances pointing at the SAME database, different agent IDs
+researcher = Brain(db_path, agent_id="researcher")
+deployer = Brain(db_path, agent_id="deployer")
+
+# ── RESEARCHER stores knowledge ─────────────────────────────────────
+print("=== Researcher Phase ===")
+researcher.log("Starting code review", event_type="session_start", project="api-v2")
+researcher.remember("Auth module uses bcrypt with cost=12", category="convention")
+researcher.remember("Database connection pool capped at 20 connections", category="environment")
+researcher.remember("All API responses must include X-Request-Id header", category="convention")
+researcher.entity("api-v2", "project", observations=["REST API", "Python 3.12", "PostgreSQL"])
+researcher.entity("AuthModule", "tool", observations=["bcrypt cost=12", "JWT tokens", "24h expiry"])
+researcher.relate("api-v2", "uses", "AuthModule")
+researcher.decide("Keep bcrypt cost at 12", "Good balance of security vs latency at current scale", project="api-v2")
+researcher.log("Completed code review", event_type="result", project="api-v2")
+print(f"  Researcher stored: {researcher.stats()['active_memories']} memories")
+
+# ── DEPLOYER discovers researcher's knowledge ────────────────────────
+print("\n=== Deployer Phase ===")
+deployer.log("Starting deployment prep", event_type="session_start", project="api-v2")
+
+# Search sees ALL agents' memories by default — no isolation
+results = deployer.search("api-v2")
+print(f"  Deployer found {len(results)} memories (including researcher's)")
+for r in results:
+    print(f"    [{r['category']}] {r['content'][:70]}")
+
+# Deployer adds its own knowledge
+deployer.remember("Staging deploy takes ~3 minutes via GitHub Actions", category="environment")
+deployer.remember("Production requires 2-person approval in Slack #deploys", category="convention")
+deployer.entity("StagingEnv", "service", observations=["us-east-1", "t3.large", "3 min deploy"])
+deployer.relate("api-v2", "deployed_to", "StagingEnv")
+deployer.log("Deployed api-v2 to staging", event_type="result", project="api-v2")
+
+# ── CROSS-AGENT STATS ────────────────────────────────────────────────
+print("\n=== Cross-Agent View ===")
+# Both agents see the same totals (shared DB)
+r_stats = researcher.stats()
+d_stats = deployer.stats()
+print(f"  Total memories: {r_stats['active_memories']} (both agents see the same count)")
+print(f"  Total entities: {r_stats['entities']}")
+print(f"  Total events: {r_stats['events']}")
+print(f"  Knowledge edges: {r_stats['knowledge_edges']}")
+
+# Deployer can also find researcher's entities
+auth_results = deployer.search("bcrypt cost")
+print(f"\n  Deployer searching 'bcrypt cost': {len(auth_results)} result(s)")
+if auth_results:
+    print(f"    Found: {auth_results[0]['content']}")
+
+print("\nNote: For agent-scoped search, use CLI: brainctl -a researcher memory search ...")
+print("      For cross-agent borrowing in MCP: memory_search(borrow_from='researcher')")

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""brainctl quickstart — the absolute minimum to get started.
+
+Run:  python examples/quickstart.py
+"""
+import os, tempfile
+from agentmemory import Brain
+
+# Use a temp path so this example doesn't touch your real brain.db
+brain = Brain(os.path.join(tempfile.gettempdir(), "quickstart_brain.db"), agent_id="quickstart")
+
+# Store memories with different categories
+brain.remember("Auth module uses JWT with 24h expiry", category="convention")
+brain.remember("Always check rate limits before bulk API calls", category="lesson", confidence=0.9)
+brain.remember("User prefers dark mode and compact layout", category="preference")
+
+# Search (uses FTS5 full-text search with porter stemming)
+results = brain.search("JWT auth")
+print(f"Search 'JWT auth': {len(results)} result(s)")
+for r in results:
+    print(f"  [{r['category']}] {r['content']}")
+
+# Build a knowledge graph
+brain.entity("Alice", "person", observations=["Senior engineer", "Owns auth module"])
+brain.entity("Acme", "organization", observations=["Series B startup", "50 engineers"])
+brain.relate("Alice", "works_at", "Acme")
+
+# Log events and decisions
+brain.log("Completed auth module review", event_type="result", project="api-v2")
+brain.decide("Keep JWT expiry at 24h", "Balance of security and UX", project="api-v2")
+
+# Check stats
+print(f"\nStats: {brain.stats()}")
+
+# Diagnostics
+dx = brain.doctor()
+print(f"Health: {'healthy' if dx['healthy'] else 'issues found'} | DB: {dx['db_size_mb']} MB")

--- a/src/agentmemory/brain.py
+++ b/src/agentmemory/brain.py
@@ -13,6 +13,17 @@ Quick start:
     brain.log("Deployed v2.0")
     brain.affect("I'm excited about this!")
     brain.stats()
+
+    # Session continuity
+    brain.handoff("finish API integration", "auth module done", "rate limiting", "add retry logic")
+    packet = brain.resume()  # fetch + consume latest handoff
+
+    # Prospective memory
+    brain.trigger("deploy failure", "deploy,failure,rollback", "check rollback procedure")
+    matches = brain.check_triggers("the deploy failed")
+
+    # Diagnostics
+    brain.doctor()
 """
 
 import json
@@ -35,6 +46,7 @@ except ImportError:
     _VEC_AVAILABLE = False
 
 _INIT_SQL_PATH = Path(__file__).parent / "db" / "init_schema.sql"
+_log = logging.getLogger(__name__)
 
 
 def _utc_now_iso() -> str:
@@ -45,9 +57,23 @@ def _now_ts() -> str:
     return _utc_now_iso()
 
 
+def _safe_fts(query: str) -> str:
+    """Sanitize a query string for FTS5 MATCH syntax."""
+    safe = re.sub(r'[^\w\s]', ' ', query).strip()
+    return " OR ".join(safe.split()) if safe else ""
+
+
+_PRIORITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+
 class Brain:
-    """Simple interface to brainctl's memory system."""
-    
+    """Python interface to brainctl's memory system.
+
+    Covers core operations (remember, search, entities, events, decisions),
+    session continuity (handoff/resume), prospective memory (triggers),
+    diagnostics (doctor), and optional vector search (vsearch).
+    """
+
     def __init__(self, db_path: Optional[str] = None, agent_id: str = "default") -> None:
         if db_path is None:
             db_path = str(get_db_path())
@@ -116,9 +142,13 @@ class Brain:
             )
             conn.commit()
         except Exception as exc:
-            logging.getLogger(__name__).warning("agent auto-register failed: %s", exc)
+            _log.warning("agent auto-register failed: %s", exc)
         return conn
-    
+
+    # ------------------------------------------------------------------
+    # Core: remember, search, forget
+    # ------------------------------------------------------------------
+
     def remember(self, content: str, category: str = "general", tags: Optional[Union[str, List[str]]] = None, confidence: float = 1.0) -> int:
         """Add a memory. Returns memory ID."""
         db = self._db()
@@ -134,16 +164,34 @@ class Brain:
             try:
                 _vec.index_memory(db, mid, content)
             except Exception as exc:
-                logging.getLogger(__name__).warning(
-                    "vec.index_memory failed for memory %s: %s", mid, exc
-                )
+                _log.warning("vec.index_memory failed for memory %s: %s", mid, exc)
         db.close()
         return mid
-    
+
     def search(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
-        """Search memories by content. Returns list of dicts."""
+        """Search memories using FTS5 full-text search with porter stemming.
+
+        Falls back to LIKE search if FTS5 table is unavailable (older DBs).
+        """
+        if not query or not query.strip():
+            return []
         db = self._db()
-        # Simple LIKE search (works without FTS5)
+        try:
+            fts_q = _safe_fts(query)
+            if fts_q:
+                rows = db.execute(
+                    "SELECT m.id, m.content, m.category, m.confidence, m.created_at "
+                    "FROM memories_fts fts JOIN memories m ON m.id = fts.rowid "
+                    "WHERE memories_fts MATCH ? AND m.retired_at IS NULL "
+                    "ORDER BY fts.rank LIMIT ?",
+                    (fts_q, limit)
+                ).fetchall()
+                results = [dict(r) for r in rows]
+                db.close()
+                return results
+        except sqlite3.OperationalError:
+            pass  # FTS5 table missing — fall back to LIKE
+        # Fallback: LIKE search
         rows = db.execute(
             "SELECT id, content, category, confidence, created_at FROM memories "
             "WHERE content LIKE ? AND retired_at IS NULL ORDER BY created_at DESC LIMIT ?",
@@ -152,7 +200,7 @@ class Brain:
         results = [dict(r) for r in rows]
         db.close()
         return results
-    
+
     def forget(self, memory_id: int) -> None:
         """Soft-delete a memory."""
         db = self._db()
@@ -160,7 +208,11 @@ class Brain:
         db.execute("UPDATE memories SET retired_at = ?, updated_at = ? WHERE id = ?", (now, now, memory_id))
         db.commit()
         db.close()
-    
+
+    # ------------------------------------------------------------------
+    # Events, entities, decisions
+    # ------------------------------------------------------------------
+
     def log(self, summary: str, event_type: str = "observation", project: Optional[str] = None, importance: float = 0.5) -> int:
         """Log an event. Returns event ID."""
         db = self._db()
@@ -173,7 +225,7 @@ class Brain:
         eid = cur.lastrowid
         db.close()
         return eid
-    
+
     def entity(self, name: str, entity_type: str, properties: Optional[Dict[str, Any]] = None, observations: Optional[List[str]] = None) -> int:
         """Create or get an entity. Returns entity ID."""
         db = self._db()
@@ -183,7 +235,7 @@ class Brain:
         if existing:
             db.close()
             return existing["id"]
-        
+
         props = json.dumps(properties) if properties else "{}"
         obs = json.dumps(observations) if observations else "[]"
         now = _now_ts()
@@ -195,7 +247,7 @@ class Brain:
         eid = cur.lastrowid
         db.close()
         return eid
-    
+
     def relate(self, from_entity: str, relation: str, to_entity: str) -> None:
         """Create a relation between two entities by name."""
         db = self._db()
@@ -211,7 +263,7 @@ class Brain:
         )
         db.commit()
         db.close()
-    
+
     def decide(self, title: str, rationale: str, project: Optional[str] = None) -> int:
         """Record a decision."""
         db = self._db()
@@ -223,7 +275,194 @@ class Brain:
         did = cur.lastrowid
         db.close()
         return did
-    
+
+    # ------------------------------------------------------------------
+    # Session continuity: handoff / resume
+    # ------------------------------------------------------------------
+
+    def handoff(self, goal: str, current_state: str, open_loops: str, next_step: str,
+                project: Optional[str] = None, title: Optional[str] = None) -> int:
+        """Create a handoff packet for session continuity. Returns packet ID.
+
+        Use before ending a session to preserve working context for the next agent.
+        """
+        for name, val in [("goal", goal), ("current_state", current_state),
+                          ("open_loops", open_loops), ("next_step", next_step)]:
+            if not val or not val.strip():
+                raise ValueError(f"{name} must be a non-empty string")
+        db = self._db()
+        now = _now_ts()
+        cur = db.execute(
+            "INSERT INTO handoff_packets (agent_id, goal, current_state, open_loops, next_step, "
+            "project, title, status, scope, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 'global', ?, ?)",
+            (self.agent_id, goal, current_state, open_loops, next_step,
+             project, title, now, now)
+        )
+        db.commit()
+        hid = cur.lastrowid
+        db.close()
+        return hid
+
+    def resume(self, project: Optional[str] = None) -> Dict[str, Any]:
+        """Fetch and auto-consume the latest pending handoff. Returns {} if none."""
+        db = self._db()
+        q = ("SELECT * FROM handoff_packets WHERE agent_id = ? AND status = 'pending'")
+        params: list = [self.agent_id]
+        if project:
+            q += " AND project = ?"
+            params.append(project)
+        q += " ORDER BY created_at DESC LIMIT 1"
+        row = db.execute(q, params).fetchone()
+        if not row:
+            db.close()
+            return {}
+        packet = dict(row)
+        now = _now_ts()
+        db.execute(
+            "UPDATE handoff_packets SET status = 'consumed', consumed_at = ?, updated_at = ? WHERE id = ?",
+            (now, now, packet["id"])
+        )
+        db.commit()
+        db.close()
+        packet["status"] = "consumed"
+        return packet
+
+    # ------------------------------------------------------------------
+    # Prospective memory: triggers
+    # ------------------------------------------------------------------
+
+    def trigger(self, condition: str, keywords: str, action: str,
+                priority: str = "medium", expires: Optional[str] = None) -> int:
+        """Create a prospective memory trigger. Returns trigger ID.
+
+        Args:
+            condition: Human-readable description of when this should fire.
+            keywords: Comma-separated keywords to match against.
+            action: What to do when the trigger fires.
+            priority: One of critical, high, medium, low.
+            expires: Optional ISO datetime when the trigger expires.
+        """
+        if priority not in _PRIORITY_ORDER:
+            raise ValueError(f"priority must be one of {list(_PRIORITY_ORDER)}")
+        db = self._db()
+        cur = db.execute(
+            "INSERT INTO memory_triggers (agent_id, trigger_condition, trigger_keywords, "
+            "action, priority, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (self.agent_id, condition, keywords, action, priority, expires, _now_ts())
+        )
+        db.commit()
+        tid = cur.lastrowid
+        db.close()
+        return tid
+
+    def check_triggers(self, query: str) -> List[Dict[str, Any]]:
+        """Check if any active triggers match a query string.
+
+        Returns list of matched triggers sorted by priority (critical first).
+        """
+        db = self._db()
+        now = _now_ts()
+        # Expire overdue triggers
+        try:
+            db.execute(
+                "UPDATE memory_triggers SET status = 'expired' "
+                "WHERE status = 'active' AND expires_at IS NOT NULL AND expires_at < ?",
+                (now,)
+            )
+            db.commit()
+        except sqlite3.OperationalError:
+            db.close()
+            return []
+        rows = db.execute(
+            "SELECT * FROM memory_triggers WHERE status = 'active' AND agent_id = ?",
+            (self.agent_id,)
+        ).fetchall()
+        query_lower = query.lower()
+        matches = []
+        for row in rows:
+            kws = [k.strip().lower() for k in (row["trigger_keywords"] or "").split(",") if k.strip()]
+            matched = [k for k in kws if k in query_lower]
+            if matched:
+                m = dict(row)
+                m["matched_keywords"] = matched
+                matches.append(m)
+        matches.sort(key=lambda m: _PRIORITY_ORDER.get(m.get("priority", "medium"), 2))
+        db.close()
+        return matches
+
+    # ------------------------------------------------------------------
+    # Diagnostics
+    # ------------------------------------------------------------------
+
+    def doctor(self) -> Dict[str, Any]:
+        """Run diagnostic checks on the brain database.
+
+        Returns a dict with ok, healthy, issues list, and stats.
+        """
+        issues: List[str] = []
+        db = self._db()
+
+        # Check core tables
+        required = ["memories", "events", "entities", "decisions", "agents",
+                     "handoff_packets", "memory_triggers", "affect_log", "knowledge_edges"]
+        existing_tables = {r[0] for r in db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()}
+        for tbl in required:
+            if tbl not in existing_tables:
+                issues.append(f"Missing table: {tbl}")
+
+        # FTS5
+        fts_ok = "memories_fts" in existing_tables
+        if not fts_ok:
+            issues.append("Missing FTS5 table: memories_fts (search will use LIKE fallback)")
+
+        # Integrity check
+        try:
+            integrity = db.execute("PRAGMA integrity_check").fetchone()[0]
+            if integrity != "ok":
+                issues.append(f"Integrity check failed: {integrity}")
+        except Exception as e:
+            issues.append(f"Integrity check error: {e}")
+
+        # Counts
+        active_memories = 0
+        try:
+            active_memories = db.execute(
+                "SELECT count(*) FROM memories WHERE retired_at IS NULL"
+            ).fetchone()[0]
+        except Exception:
+            pass
+
+        # Orphan memories (agent_id not in agents table)
+        orphans = 0
+        try:
+            orphans = db.execute(
+                "SELECT count(*) FROM memories WHERE agent_id NOT IN (SELECT id FROM agents)"
+            ).fetchone()[0]
+            if orphans > 0:
+                issues.append(f"{orphans} orphaned memories (agent_id not in agents table)")
+        except Exception:
+            pass
+
+        db.close()
+
+        # DB file size
+        db_size_mb = round(self.db_path.stat().st_size / (1024 * 1024), 2) if self.db_path.exists() else 0.0
+
+        healthy = len(issues) == 0
+        return {
+            "ok": True,
+            "healthy": healthy,
+            "issues": issues,
+            "active_memories": active_memories,
+            "fts5_available": fts_ok,
+            "vec_available": _VEC_AVAILABLE,
+            "db_size_mb": db_size_mb,
+            "db_path": str(self.db_path),
+        }
+
     def stats(self) -> Dict[str, int]:
         """Get database statistics."""
         db = self._db()
@@ -241,6 +480,94 @@ class Brain:
             stats["active_memories"] = 0
         db.close()
         return stats
+
+    # ------------------------------------------------------------------
+    # Vector search (optional — requires sqlite-vec + Ollama)
+    # ------------------------------------------------------------------
+
+    def vsearch(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """Vector similarity search. Returns [] if sqlite-vec is unavailable.
+
+        Requires: pip install brainctl[vec] and Ollama running locally.
+        """
+        if not _VEC_AVAILABLE or _vec is None:
+            return []
+        db = self._db()
+        try:
+            results = _vec.vec_search(db, query, k=limit)
+        except Exception as exc:
+            _log.debug("vsearch failed: %s", exc)
+            results = []
+        db.close()
+        return results
+
+    # ------------------------------------------------------------------
+    # Consolidation (simplified single-pass)
+    # ------------------------------------------------------------------
+
+    def consolidate(self, limit: int = 50, min_priority: float = 0.1) -> Dict[str, Any]:
+        """Run a single consolidation pass: promote high-replay episodic memories to semantic.
+
+        Promotes episodic memories with replay_priority >= min_priority, ripple_tags >= 3,
+        and confidence >= 0.7 to semantic memory_type. Resets replay_priority after processing.
+        """
+        db = self._db()
+        try:
+            rows = db.execute(
+                "SELECT id, memory_type, ripple_tags, confidence FROM memories "
+                "WHERE retired_at IS NULL AND replay_priority >= ? "
+                "ORDER BY replay_priority DESC LIMIT ?",
+                (min_priority, limit)
+            ).fetchall()
+        except sqlite3.OperationalError:
+            db.close()
+            return {"ok": False, "error": "replay_priority column not available (run brainctl migrate)"}
+
+        processed = 0
+        promoted = 0
+        now = _now_ts()
+        for row in rows:
+            processed += 1
+            if (row["memory_type"] == "episodic"
+                    and (row["ripple_tags"] or 0) >= 3
+                    and (row["confidence"] or 0) >= 0.7):
+                db.execute(
+                    "UPDATE memories SET memory_type = 'semantic', updated_at = ? WHERE id = ?",
+                    (now, row["id"])
+                )
+                promoted += 1
+            db.execute(
+                "UPDATE memories SET replay_priority = 0.0 WHERE id = ?",
+                (row["id"],)
+            )
+        db.commit()
+        db.close()
+        return {"ok": True, "processed": processed, "promoted": promoted}
+
+    # ------------------------------------------------------------------
+    # Tier stats (D-MEM write-tier distribution)
+    # ------------------------------------------------------------------
+
+    def tier_stats(self) -> Dict[str, Any]:
+        """Show write-tier distribution (full/construct) for this agent."""
+        db = self._db()
+        try:
+            rows = db.execute(
+                "SELECT write_tier, count(*) as cnt FROM memories "
+                "WHERE retired_at IS NULL AND agent_id = ? GROUP BY write_tier",
+                (self.agent_id,)
+            ).fetchall()
+        except sqlite3.OperationalError:
+            db.close()
+            return {"ok": False, "error": "write_tier column not available (run brainctl migrate)"}
+        total = sum(r["cnt"] for r in rows)
+        tiers = {r["write_tier"]: r["cnt"] for r in rows}
+        db.close()
+        return {"ok": True, "total": total, "tiers": tiers}
+
+    # ------------------------------------------------------------------
+    # Affect
+    # ------------------------------------------------------------------
 
     def affect(self, text: str) -> Dict[str, Any]:
         """Classify affect from text. Returns VAD scores and labels."""

--- a/tests/test_brain_enhanced.py
+++ b/tests/test_brain_enhanced.py
@@ -1,0 +1,270 @@
+"""Tests for enhanced Brain class: FTS5 search, triggers, handoffs, doctor, vsearch, consolidate, tier_stats."""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from agentmemory.brain import Brain
+
+
+@pytest.fixture
+def brain(tmp_path):
+    """Fresh Brain with isolated DB."""
+    return Brain(db_path=str(tmp_path / "brain.db"), agent_id="test-agent")
+
+
+# ---------------------------------------------------------------------------
+# search() — FTS5
+# ---------------------------------------------------------------------------
+
+
+class TestSearchFTS5:
+    def test_basic_search(self, brain):
+        brain.remember("JWT tokens expire after 24 hours", category="convention")
+        results = brain.search("JWT tokens")
+        assert len(results) >= 1
+        assert "JWT" in results[0]["content"]
+
+    def test_search_with_stemming(self, brain):
+        brain.remember("deploying the application to production", category="environment")
+        # FTS5 porter stemmer: "deployed" should match "deploying"
+        results = brain.search("deployed")
+        assert len(results) >= 1
+
+    def test_search_returns_ranked_results(self, brain):
+        brain.remember("rate limiting configuration", category="convention")
+        brain.remember("rate limiting is 100 requests per 15 seconds", category="integration")
+        brain.remember("database connection pool size", category="environment")
+        results = brain.search("rate limiting")
+        assert len(results) >= 2
+        # Top results should be about rate limiting, not database
+        assert "rate" in results[0]["content"].lower()
+
+    def test_search_excludes_retired(self, brain):
+        mid = brain.remember("temporary fact", category="convention")
+        brain.forget(mid)
+        results = brain.search("temporary fact")
+        assert len(results) == 0
+
+    def test_search_limit(self, brain):
+        for i in range(10):
+            brain.remember(f"memory number {i} about testing", category="lesson")
+        results = brain.search("testing", limit=3)
+        assert len(results) <= 3
+
+    def test_search_empty_query(self, brain):
+        brain.remember("something", category="lesson")
+        results = brain.search("")
+        assert results == []
+
+    def test_search_special_characters(self, brain):
+        brain.remember("use the --force flag carefully", category="convention")
+        results = brain.search("--force flag")
+        assert len(results) >= 1
+
+    def test_search_result_fields(self, brain):
+        brain.remember("test content", category="lesson", confidence=0.9)
+        results = brain.search("test content")
+        assert len(results) >= 1
+        r = results[0]
+        assert "id" in r
+        assert "content" in r
+        assert "category" in r
+        assert "confidence" in r
+        assert "created_at" in r
+
+
+# ---------------------------------------------------------------------------
+# trigger() + check_triggers()
+# ---------------------------------------------------------------------------
+
+
+class TestTriggers:
+    def test_create_trigger(self, brain):
+        tid = brain.trigger("when deploy fails", "deploy,failure", "check rollback")
+        assert isinstance(tid, int)
+        assert tid > 0
+
+    def test_check_triggers_match(self, brain):
+        brain.trigger("deploy issue", "deploy,failure,rollback", "check rollback procedure")
+        matches = brain.check_triggers("the deploy failed with a rollback")
+        assert len(matches) >= 1
+        assert "deploy" in matches[0]["matched_keywords"] or "failure" in matches[0]["matched_keywords"]
+
+    def test_check_triggers_no_match(self, brain):
+        brain.trigger("deploy issue", "deploy,failure", "check rollback")
+        matches = brain.check_triggers("the database is running slow")
+        assert len(matches) == 0
+
+    def test_trigger_priority_order(self, brain):
+        brain.trigger("low priority", "alert", "log it", priority="low")
+        brain.trigger("critical alert", "alert", "page oncall", priority="critical")
+        matches = brain.check_triggers("new alert detected")
+        assert len(matches) == 2
+        assert matches[0]["priority"] == "critical"
+        assert matches[1]["priority"] == "low"
+
+    def test_trigger_invalid_priority(self, brain):
+        with pytest.raises(ValueError):
+            brain.trigger("test", "test", "test", priority="urgent")
+
+    def test_trigger_expiry(self, brain):
+        brain.trigger("old trigger", "expired", "do nothing", expires="2020-01-01T00:00:00")
+        matches = brain.check_triggers("this is expired content")
+        assert len(matches) == 0
+
+
+# ---------------------------------------------------------------------------
+# handoff() + resume()
+# ---------------------------------------------------------------------------
+
+
+class TestHandoffs:
+    def test_create_handoff(self, brain):
+        hid = brain.handoff(
+            goal="finish API integration",
+            current_state="auth module complete",
+            open_loops="rate limiting not implemented",
+            next_step="add retry logic with exponential backoff",
+        )
+        assert isinstance(hid, int)
+        assert hid > 0
+
+    def test_resume_consumes_handoff(self, brain):
+        brain.handoff("goal", "state", "loops", "next")
+        packet = brain.resume()
+        assert packet != {}
+        assert packet["goal"] == "goal"
+        assert packet["status"] == "consumed"
+        # Second resume should return empty
+        packet2 = brain.resume()
+        assert packet2 == {}
+
+    def test_resume_empty(self, brain):
+        assert brain.resume() == {}
+
+    def test_resume_with_project(self, brain):
+        brain.handoff("goal A", "state A", "loops A", "next A", project="alpha")
+        brain.handoff("goal B", "state B", "loops B", "next B", project="beta")
+        packet = brain.resume(project="alpha")
+        assert packet["goal"] == "goal A"
+
+    def test_handoff_requires_nonempty(self, brain):
+        with pytest.raises(ValueError):
+            brain.handoff("", "state", "loops", "next")
+        with pytest.raises(ValueError):
+            brain.handoff("goal", "  ", "loops", "next")
+
+    def test_handoff_with_title(self, brain):
+        hid = brain.handoff("goal", "state", "loops", "next", title="Sprint 42 handoff")
+        packet = brain.resume()
+        assert packet["title"] == "Sprint 42 handoff"
+
+
+# ---------------------------------------------------------------------------
+# doctor()
+# ---------------------------------------------------------------------------
+
+
+class TestDoctor:
+    def test_healthy_db(self, brain):
+        result = brain.doctor()
+        assert result["ok"] is True
+        assert result["healthy"] is True
+        assert result["issues"] == []
+        assert result["fts5_available"] is True
+        assert isinstance(result["db_size_mb"], float)
+        assert result["db_path"] == str(brain.db_path)
+
+    def test_reports_active_memories(self, brain):
+        brain.remember("fact one", category="lesson")
+        brain.remember("fact two", category="lesson")
+        result = brain.doctor()
+        assert result["active_memories"] == 2
+
+    def test_reports_vec_availability(self, brain):
+        result = brain.doctor()
+        assert "vec_available" in result
+        assert isinstance(result["vec_available"], bool)
+
+
+# ---------------------------------------------------------------------------
+# vsearch()
+# ---------------------------------------------------------------------------
+
+
+class TestVsearch:
+    def test_returns_list(self, brain):
+        result = brain.vsearch("anything")
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# consolidate()
+# ---------------------------------------------------------------------------
+
+
+class TestConsolidate:
+    def test_empty_consolidation(self, brain):
+        result = brain.consolidate()
+        assert result["ok"] is True
+        assert result["processed"] == 0
+        assert result["promoted"] == 0
+
+    def test_promotes_eligible_memory(self, brain):
+        db_file = brain.db_path
+        mid = brain.remember("important pattern observed repeatedly", category="lesson", confidence=0.9)
+        # Set high replay_priority and ripple_tags to make eligible
+        conn = sqlite3.connect(str(db_file))
+        conn.execute(
+            "UPDATE memories SET replay_priority = 5.0, ripple_tags = 5 WHERE id = ?",
+            (mid,)
+        )
+        conn.commit()
+        conn.close()
+        result = brain.consolidate()
+        assert result["ok"] is True
+        assert result["promoted"] >= 1
+        # Verify memory_type changed
+        conn = sqlite3.connect(str(db_file))
+        row = conn.execute("SELECT memory_type FROM memories WHERE id = ?", (mid,)).fetchone()
+        conn.close()
+        assert row[0] == "semantic"
+
+    def test_does_not_promote_low_confidence(self, brain):
+        mid = brain.remember("weak observation", category="lesson", confidence=0.3)
+        conn = sqlite3.connect(str(brain.db_path))
+        conn.execute(
+            "UPDATE memories SET replay_priority = 5.0, ripple_tags = 5 WHERE id = ?",
+            (mid,)
+        )
+        conn.commit()
+        conn.close()
+        result = brain.consolidate()
+        assert result["promoted"] == 0
+
+
+# ---------------------------------------------------------------------------
+# tier_stats()
+# ---------------------------------------------------------------------------
+
+
+class TestTierStats:
+    def test_empty_db(self, brain):
+        result = brain.tier_stats()
+        assert result["ok"] is True
+        assert result["total"] == 0
+
+    def test_counts_memories(self, brain):
+        brain.remember("fact one", category="lesson")
+        brain.remember("fact two", category="lesson")
+        result = brain.tier_stats()
+        assert result["ok"] is True
+        assert result["total"] == 2


### PR DESCRIPTION
## Summary

Built by an agent, for agents. Addresses the cliff between "Brain() works in 2 minutes" and "now learn 192 MCP tools."

### Brain class: 10 methods -> 19
- `search()` upgraded from LIKE to FTS5 full-text search with porter stemming (graceful fallback for old DBs)
- `trigger()` + `check_triggers()` — prospective memory (set conditions, match against queries)
- `handoff()` + `resume()` — session continuity with auto-consume
- `doctor()` — diagnostic health check (tables, integrity, vec, orphans, DB size)
- `vsearch()` — vector similarity search (returns `[]` if sqlite-vec unavailable)
- `consolidate()` — single-pass episodic-to-semantic promotion on replay queue
- `tier_stats()` — D-MEM write-tier distribution

### examples/ directory
- `quickstart.py` — 30-line minimum viable agent
- `agent_lifecycle.py` — Orient-Work-Record with handoff + triggers
- `multi_agent.py` — two agents sharing knowledge through one brain.db

### docs/AGENT_ONBOARDING.md
Step-by-step guide: prerequisites, quickstart (Python + CLI), core concepts, write gate, search modes, session continuity, diagnostics, patterns by agent type, anti-patterns, cheat sheet

### MCP_SERVER.md enhancement
"Which tools do I need?" section: 3 tiers (essential ~15 / advanced ~30 / specialist ~150) + text decision tree

## Test plan
- [x] `tests/test_brain_enhanced.py` — 29 new tests covering all new Brain methods
- [x] Full suite: 1255 tests passing
- [x] All 3 examples run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)