### PR TITLE
feat: LangChain + CrewAI integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,47 @@ brain.wrap_up("what I accomplished")  # session end: logs event + creates handof
 
 See [examples/](examples/) for runnable scripts and [docs/AGENT_ONBOARDING.md](docs/AGENT_ONBOARDING.md) for the full agent integration guide.
 
+## Framework Integrations
+
+### LangChain
+
+```bash
+pip install brainctl langchain-core
+```
+
+```python
+from agentmemory.integrations.langchain import BrainctlChatMessageHistory
+from langchain_core.runnables.history import RunnableWithMessageHistory
+
+chain_with_history = RunnableWithMessageHistory(
+    runnable=my_chain,
+    get_session_history=lambda sid: BrainctlChatMessageHistory(session_id=sid),
+)
+```
+
+Chat messages persist in brain.db. The Brain instance is accessible via `history.brain` for knowledge operations beyond chat (entities, decisions, triggers, search).
+
+### CrewAI
+
+```bash
+pip install brainctl crewai
+```
+
+```python
+from crewai import Crew
+from crewai.memory import ShortTermMemory, LongTermMemory, EntityMemory
+from agentmemory.integrations.crewai import BrainctlStorage
+
+crew = Crew(
+    agents=[...], tasks=[...], memory=True,
+    short_term_memory=ShortTermMemory(storage=BrainctlStorage("short-term")),
+    long_term_memory=LongTermMemory(storage=BrainctlStorage("long-term")),
+    entity_memory=EntityMemory(storage=BrainctlStorage("entity")),
+)
+```
+
+All crew memory goes to a single brain.db. FTS5 search out of the box, optional vector search with `pip install brainctl[vec]`.
+
 ## Python API (21 methods)
 
 | Method | What it does |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ classifiers = [
 mcp = ["mcp>=1.27.0"]
 vec = ["sqlite-vec>=0.1.0"]
 obsidian = ["watchdog>=3.0.0"]
+langchain = ["langchain-core>=0.3.0"]
+crewai = ["crewai>=0.80.0"]
 all = ["mcp>=1.27.0", "sqlite-vec>=0.1.0", "watchdog>=3.0.0"]
 
 [project.scripts]

--- a/src/agentmemory/integrations/__init__.py
+++ b/src/agentmemory/integrations/__init__.py
@@ -1,0 +1,9 @@
+"""brainctl framework integrations.
+
+Import the adapter for your framework:
+
+    from agentmemory.integrations.langchain import BrainctlChatMessageHistory
+    from agentmemory.integrations.crewai import BrainctlRAGStorage
+
+Each integration requires the respective framework to be installed.
+"""

--- a/src/agentmemory/integrations/crewai.py
+++ b/src/agentmemory/integrations/crewai.py
@@ -1,0 +1,178 @@
+"""CrewAI integration for brainctl.
+
+Provides RAGStorage backed by brain.db for CrewAI's memory system.
+brainctl handles both FTS5 search and optional vector search — no separate
+vector DB required.
+
+Install: pip install brainctl crewai
+
+Usage:
+
+    from crewai import Crew, Agent, Task
+    from agentmemory.integrations.crewai import BrainctlStorage
+
+    crew = Crew(
+        agents=[agent1, agent2],
+        tasks=[task1, task2],
+        memory=True,
+        short_term_memory=ShortTermMemory(storage=BrainctlStorage("short-term")),
+        long_term_memory=LongTermMemory(storage=BrainctlStorage("long-term")),
+        entity_memory=EntityMemory(storage=BrainctlStorage("entity")),
+    )
+
+Or with the unified memory interface (CrewAI 0.100+):
+
+    from agentmemory.integrations.crewai import BrainctlStorage
+    storage = BrainctlStorage("crew-memory")
+    # Pass to crew or agent memory configuration
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+try:
+    from crewai.memory.storage.rag_storage import RAGStorage
+except ImportError as e:
+    raise ImportError(
+        "crewai is required for the CrewAI integration. "
+        "Install it with: pip install crewai"
+    ) from e
+
+from agentmemory.brain import Brain
+
+
+class BrainctlStorage(RAGStorage):
+    """CrewAI RAGStorage backed by brainctl's brain.db.
+
+    Stores CrewAI memory items as brainctl memories with metadata preserved
+    in tags. Search uses FTS5 full-text search with optional vector similarity
+    if sqlite-vec is available.
+
+    Args:
+        type: Memory type identifier (e.g., "short-term", "long-term", "entity").
+        db_path: Path to brain.db. Defaults to ~/agentmemory/db/brain.db.
+        agent_id: Agent attribution. Defaults to "crewai".
+        embedder_config: CrewAI embedder configuration (ignored — brainctl handles its own embeddings).
+        crew: CrewAI Crew reference (stored but not used).
+    """
+
+    def __init__(
+        self,
+        type: str,
+        db_path: Optional[str] = None,
+        agent_id: str = "crewai",
+        embedder_config: Optional[Dict[str, Any]] = None,
+        crew: Any = None,
+    ) -> None:
+        self.type = type
+        self.brain = Brain(db_path=db_path, agent_id=agent_id)
+        self._crew = crew
+
+    def _initialize_app(self) -> None:
+        """Initialize storage backend. Brain auto-initializes, so this is a no-op."""
+        pass
+
+    def _category_for_type(self) -> str:
+        """Map CrewAI memory type to brainctl category."""
+        mapping = {
+            "short-term": "project",
+            "long-term": "lesson",
+            "entity": "integration",
+            "crew-memory": "project",
+        }
+        return mapping.get(self.type, "project")
+
+    def save(self, value: Any, metadata: Optional[Dict[str, Any]] = None, agent: Optional[str] = None) -> None:
+        """Store a memory item in brain.db.
+
+        Args:
+            value: The text content to store.
+            metadata: Optional metadata dict (preserved in memory tags).
+            agent: Optional agent name for attribution.
+        """
+        content = str(value) if not isinstance(value, str) else value
+        if not content.strip():
+            return
+
+        category = self._category_for_type()
+        tags = None
+        confidence = 0.8
+
+        if metadata:
+            # Extract useful fields from CrewAI metadata
+            if "categories" in metadata:
+                cats = metadata["categories"]
+                if isinstance(cats, list) and cats:
+                    category = cats[0] if cats[0] in (
+                        "identity", "user", "environment", "convention", "project",
+                        "decision", "lesson", "preference", "integration"
+                    ) else category
+            if "importance" in metadata:
+                confidence = max(0.1, min(1.0, float(metadata["importance"])))
+            # Store full metadata as tags for round-tripping
+            tags = json.dumps({"crewai_type": self.type, "crewai_meta": metadata})
+
+        self.brain.remember(content, category=category, tags=tags, confidence=confidence)
+
+    def search(
+        self,
+        query: str,
+        limit: int = 3,
+        filter: Optional[Dict[str, Any]] = None,
+        score_threshold: float = 0.0,
+    ) -> List[Dict[str, Any]]:
+        """Search brain.db for relevant memories.
+
+        Returns list of dicts with keys: id, metadata, context, score.
+        Uses FTS5 search with optional vector search fallback.
+        """
+        # Try vector search first (better semantic matching), fall back to FTS5
+        results = self.brain.vsearch(query, limit=limit)
+        if not results:
+            results = self.brain.search(query, limit=limit)
+
+        items = []
+        for r in results:
+            # Normalize score: FTS5 doesn't have distance, vec has distance (lower=better)
+            if "distance" in r:
+                score = max(0.0, 1.0 - r["distance"])
+            else:
+                score = r.get("confidence", 0.5)
+
+            if score < score_threshold:
+                continue
+
+            meta = {
+                "id": r.get("id"),
+                "category": r.get("category"),
+                "confidence": r.get("confidence"),
+                "created_at": r.get("created_at"),
+                "crewai_type": self.type,
+            }
+            items.append({
+                "id": str(r.get("id", "")),
+                "metadata": meta,
+                "context": r.get("content", ""),
+                "score": round(score, 4),
+            })
+        return items
+
+    def reset(self) -> None:
+        """Clear all memories stored by this storage instance.
+
+        Only retires memories tagged with this CrewAI memory type to avoid
+        destroying unrelated brainctl data.
+        """
+        db = self.brain._db()
+        from agentmemory.brain import _now_ts
+        now = _now_ts()
+        # Only retire memories that have our crewai_type tag
+        db.execute(
+            "UPDATE memories SET retired_at = ? "
+            "WHERE agent_id = ? AND retired_at IS NULL "
+            "AND tags LIKE ?",
+            (now, self.brain.agent_id, f'%"crewai_type": "{self.type}"%'),
+        )
+        db.commit()
+        db.close()

--- a/src/agentmemory/integrations/langchain.py
+++ b/src/agentmemory/integrations/langchain.py
@@ -1,0 +1,144 @@
+"""LangChain integration for brainctl.
+
+Provides BaseChatMessageHistory backed by brain.db, plus direct Brain access
+for knowledge operations (entities, decisions, triggers) that go beyond chat.
+
+Install: pip install brainctl langchain-core
+
+Usage with LangGraph / LCEL:
+
+    from agentmemory.integrations.langchain import BrainctlChatMessageHistory
+    from langchain_core.runnables.history import RunnableWithMessageHistory
+
+    def get_session_history(session_id: str):
+        return BrainctlChatMessageHistory(session_id=session_id)
+
+    chain_with_history = RunnableWithMessageHistory(
+        runnable=my_chain,
+        get_session_history=get_session_history,
+    )
+
+Direct Brain access (for knowledge beyond chat):
+
+    history = BrainctlChatMessageHistory(session_id="sess-1")
+    history.brain.remember("API rate-limits at 100/15s", category="integration")
+    history.brain.entity("RateLimitAPI", "service")
+    results = history.brain.search("rate limit")
+"""
+from __future__ import annotations
+
+import json
+from typing import List, Optional, Sequence
+
+try:
+    from langchain_core.chat_history import BaseChatMessageHistory
+    from langchain_core.messages import (
+        AIMessage,
+        BaseMessage,
+        HumanMessage,
+        SystemMessage,
+        messages_from_dict,
+        message_to_dict,
+    )
+except ImportError as e:
+    raise ImportError(
+        "langchain-core is required for the LangChain integration. "
+        "Install it with: pip install langchain-core"
+    ) from e
+
+from agentmemory.brain import Brain
+
+
+class BrainctlChatMessageHistory(BaseChatMessageHistory):
+    """Chat message history backed by brainctl's brain.db.
+
+    Messages are stored as events in the events table with type 'chat_message'.
+    The full message (role + content) is preserved in the event's metadata field
+    so round-tripping is lossless.
+
+    The Brain instance is exposed as `self.brain` for knowledge operations
+    that go beyond chat history (entities, decisions, triggers, search).
+
+    Args:
+        session_id: Unique session identifier. Used to scope messages.
+        db_path: Path to brain.db. Defaults to ~/agentmemory/db/brain.db.
+        agent_id: Agent attribution for writes. Defaults to "langchain".
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        db_path: Optional[str] = None,
+        agent_id: str = "langchain",
+    ) -> None:
+        self.session_id = session_id
+        self.brain = Brain(db_path=db_path, agent_id=agent_id)
+
+    @property
+    def messages(self) -> List[BaseMessage]:
+        """Retrieve all messages for this session, ordered chronologically."""
+        db = self.brain._db()
+        rows = db.execute(
+            "SELECT metadata FROM events "
+            "WHERE agent_id = ? AND session_id = ? AND event_type = 'chat_message' "
+            "ORDER BY created_at ASC",
+            (self.brain.agent_id, self.session_id),
+        ).fetchall()
+        db.close()
+
+        msgs: List[BaseMessage] = []
+        for row in rows:
+            try:
+                data = json.loads(row["metadata"])
+                msg_type = data.get("type", "human")
+                content = data.get("content", "")
+                if msg_type == "ai":
+                    msgs.append(AIMessage(content=content))
+                elif msg_type == "system":
+                    msgs.append(SystemMessage(content=content))
+                else:
+                    msgs.append(HumanMessage(content=content))
+            except (json.JSONDecodeError, TypeError):
+                continue
+        return msgs
+
+    def add_messages(self, messages: Sequence[BaseMessage]) -> None:
+        """Persist messages to brain.db as events."""
+        db = self.brain._db()
+        from agentmemory.brain import _now_ts
+        now = _now_ts()
+        for msg in messages:
+            msg_type = "human"
+            if isinstance(msg, AIMessage):
+                msg_type = "ai"
+            elif isinstance(msg, SystemMessage):
+                msg_type = "system"
+
+            metadata = json.dumps({
+                "type": msg_type,
+                "content": msg.content if isinstance(msg.content, str) else str(msg.content),
+            })
+            db.execute(
+                "INSERT INTO events (agent_id, event_type, summary, metadata, session_id, created_at) "
+                "VALUES (?, 'chat_message', ?, ?, ?, ?)",
+                (
+                    self.brain.agent_id,
+                    f"[{msg_type}] {str(msg.content)[:100]}",
+                    metadata,
+                    self.session_id,
+                    now,
+                ),
+            )
+        db.commit()
+        db.close()
+
+    def clear(self) -> None:
+        """Remove all messages for this session."""
+        db = self.brain._db()
+        db.execute(
+            "DELETE FROM events "
+            "WHERE agent_id = ? AND session_id = ? AND event_type = 'chat_message'",
+            (self.brain.agent_id, self.session_id),
+        )
+        db.commit()
+        db.close()

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,263 @@
+"""Tests for framework integrations (LangChain, CrewAI).
+
+Tests mock the framework imports so they run without langchain-core or crewai installed.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# ---------------------------------------------------------------------------
+# Mock frameworks before importing integrations
+# ---------------------------------------------------------------------------
+
+
+def _mock_langchain():
+    """Mock langchain_core so the integration can import."""
+    # Create mock message classes
+    class BaseMessage:
+        def __init__(self, content="", **kwargs):
+            self.content = content
+
+    class HumanMessage(BaseMessage):
+        pass
+
+    class AIMessage(BaseMessage):
+        pass
+
+    class SystemMessage(BaseMessage):
+        pass
+
+    class BaseChatMessageHistory:
+        pass
+
+    def messages_from_dict(dicts):
+        return []
+
+    def message_to_dict(msg):
+        return {}
+
+    # Wire up mock modules
+    chat_history = types.ModuleType("langchain_core.chat_history")
+    chat_history.BaseChatMessageHistory = BaseChatMessageHistory
+
+    messages = types.ModuleType("langchain_core.messages")
+    messages.BaseMessage = BaseMessage
+    messages.HumanMessage = HumanMessage
+    messages.AIMessage = AIMessage
+    messages.SystemMessage = SystemMessage
+    messages.messages_from_dict = messages_from_dict
+    messages.message_to_dict = message_to_dict
+
+    langchain_core = types.ModuleType("langchain_core")
+    sys.modules["langchain_core"] = langchain_core
+    sys.modules["langchain_core.chat_history"] = chat_history
+    sys.modules["langchain_core.messages"] = messages
+
+    return HumanMessage, AIMessage, SystemMessage
+
+
+def _mock_crewai():
+    """Mock crewai so the integration can import."""
+    class RAGStorage:
+        def __init__(self, *args, **kwargs):
+            pass
+        def save(self, value, metadata=None, agent=None):
+            pass
+        def search(self, query, limit=3, filter=None, score_threshold=0.0):
+            return []
+        def reset(self):
+            pass
+        def _initialize_app(self):
+            pass
+
+    rag_storage = types.ModuleType("crewai.memory.storage.rag_storage")
+    rag_storage.RAGStorage = RAGStorage
+
+    memory_storage = types.ModuleType("crewai.memory.storage")
+    memory = types.ModuleType("crewai.memory")
+    crewai = types.ModuleType("crewai")
+
+    sys.modules["crewai"] = crewai
+    sys.modules["crewai.memory"] = memory
+    sys.modules["crewai.memory.storage"] = memory_storage
+    sys.modules["crewai.memory.storage.rag_storage"] = rag_storage
+
+
+# Set up mocks before importing
+HumanMessage, AIMessage, SystemMessage = _mock_langchain()
+_mock_crewai()
+
+from agentmemory.integrations.langchain import BrainctlChatMessageHistory
+from agentmemory.integrations.crewai import BrainctlStorage
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "brain.db")
+
+
+# ---------------------------------------------------------------------------
+# LangChain: BrainctlChatMessageHistory
+# ---------------------------------------------------------------------------
+
+
+class TestLangChainHistory:
+    def test_empty_history(self, tmp_db):
+        history = BrainctlChatMessageHistory(session_id="sess-1", db_path=tmp_db)
+        assert history.messages == []
+
+    def test_add_and_retrieve_messages(self, tmp_db):
+        history = BrainctlChatMessageHistory(session_id="sess-1", db_path=tmp_db)
+        history.add_messages([
+            HumanMessage(content="What's the weather?"),
+            AIMessage(content="It's sunny today."),
+        ])
+        msgs = history.messages
+        assert len(msgs) == 2
+        assert msgs[0].content == "What's the weather?"
+        assert msgs[1].content == "It's sunny today."
+
+    def test_session_isolation(self, tmp_db):
+        h1 = BrainctlChatMessageHistory(session_id="sess-1", db_path=tmp_db)
+        h2 = BrainctlChatMessageHistory(session_id="sess-2", db_path=tmp_db)
+        h1.add_messages([HumanMessage(content="session 1 message")])
+        h2.add_messages([HumanMessage(content="session 2 message")])
+        assert len(h1.messages) == 1
+        assert len(h2.messages) == 1
+        assert h1.messages[0].content == "session 1 message"
+        assert h2.messages[0].content == "session 2 message"
+
+    def test_clear(self, tmp_db):
+        history = BrainctlChatMessageHistory(session_id="sess-1", db_path=tmp_db)
+        history.add_messages([HumanMessage(content="hello")])
+        assert len(history.messages) == 1
+        history.clear()
+        assert len(history.messages) == 0
+
+    def test_message_types_preserved(self, tmp_db):
+        history = BrainctlChatMessageHistory(session_id="sess-1", db_path=tmp_db)
+        history.add_messages([
+            SystemMessage(content="You are a helpful assistant."),
+            HumanMessage(content="Hi"),
+            AIMessage(content="Hello!"),
+        ])
+        msgs = history.messages
+        assert len(msgs) == 3
+        # Check types via the metadata stored in events
+        db = history.brain._db()
+        rows = db.execute(
+            "SELECT metadata FROM events WHERE session_id = 'sess-1' ORDER BY created_at"
+        ).fetchall()
+        db.close()
+        types = [json.loads(r["metadata"])["type"] for r in rows]
+        assert types == ["system", "human", "ai"]
+
+    def test_brain_access(self, tmp_db):
+        history = BrainctlChatMessageHistory(session_id="sess-1", db_path=tmp_db)
+        mid = history.brain.remember("Important fact", category="lesson")
+        assert mid > 0
+        results = history.brain.search("important fact")
+        assert len(results) >= 1
+
+    def test_chronological_order(self, tmp_db):
+        history = BrainctlChatMessageHistory(session_id="sess-1", db_path=tmp_db)
+        history.add_messages([HumanMessage(content="first")])
+        history.add_messages([HumanMessage(content="second")])
+        history.add_messages([HumanMessage(content="third")])
+        msgs = history.messages
+        assert [m.content for m in msgs] == ["first", "second", "third"]
+
+
+# ---------------------------------------------------------------------------
+# CrewAI: BrainctlStorage
+# ---------------------------------------------------------------------------
+
+
+class TestCrewAIStorage:
+    def test_save_and_search(self, tmp_db):
+        storage = BrainctlStorage(type="short-term", db_path=tmp_db)
+        storage.save("The API rate-limits at 100 requests per 15 seconds")
+        results = storage.search("rate limit")
+        assert len(results) >= 1
+        assert "rate" in results[0]["context"].lower()
+
+    def test_search_returns_correct_format(self, tmp_db):
+        storage = BrainctlStorage(type="long-term", db_path=tmp_db)
+        storage.save("PostgreSQL connection pool is capped at 20")
+        results = storage.search("connection pool")
+        assert len(results) >= 1
+        r = results[0]
+        assert "id" in r
+        assert "metadata" in r
+        assert "context" in r
+        assert "score" in r
+        assert isinstance(r["score"], float)
+
+    def test_save_with_metadata(self, tmp_db):
+        storage = BrainctlStorage(type="short-term", db_path=tmp_db)
+        storage.save(
+            "JWT tokens expire after 24 hours",
+            metadata={"importance": 0.9, "categories": ["convention"]},
+        )
+        results = storage.search("JWT expire")
+        assert len(results) >= 1
+
+    def test_type_to_category_mapping(self, tmp_db):
+        st = BrainctlStorage(type="short-term", db_path=tmp_db)
+        lt = BrainctlStorage(type="long-term", db_path=tmp_db)
+        ent = BrainctlStorage(type="entity", db_path=tmp_db)
+        assert st._category_for_type() == "project"
+        assert lt._category_for_type() == "lesson"
+        assert ent._category_for_type() == "integration"
+
+    def test_reset_only_retires_own_type(self, tmp_db):
+        st = BrainctlStorage(type="short-term", db_path=tmp_db)
+        lt = BrainctlStorage(type="long-term", db_path=tmp_db)
+        st.save("short term fact")
+        lt.save("long term fact")
+        st.reset()
+        # Long-term memories should survive
+        lt_results = lt.search("long term")
+        assert len(lt_results) >= 1
+
+    def test_empty_search(self, tmp_db):
+        storage = BrainctlStorage(type="short-term", db_path=tmp_db)
+        results = storage.search("nonexistent query xyz123")
+        assert results == []
+
+    def test_score_threshold(self, tmp_db):
+        storage = BrainctlStorage(type="short-term", db_path=tmp_db)
+        storage.save("testing score threshold behavior")
+        results = storage.search("testing score", score_threshold=0.99)
+        # High threshold should filter out most results
+        # (FTS5 confidence is typically < 0.99)
+        assert isinstance(results, list)
+
+    def test_brain_accessible(self, tmp_db):
+        storage = BrainctlStorage(type="short-term", db_path=tmp_db)
+        assert hasattr(storage, "brain")
+        stats = storage.brain.stats()
+        assert "active_memories" in stats
+
+    def test_empty_value_ignored(self, tmp_db):
+        storage = BrainctlStorage(type="short-term", db_path=tmp_db)
+        storage.save("")
+        storage.save("   ")
+        assert storage.brain.stats()["active_memories"] == 0


### PR DESCRIPTION
## Summary

Framework adapters that put brainctl in front of two major agent ecosystems. Users searching for "LangChain persistent memory" or "CrewAI memory backend" can now land on brainctl.

### LangChain
```python
from agentmemory.integrations.langchain import BrainctlChatMessageHistory
chain_with_history = RunnableWithMessageHistory(
    runnable=my_chain,
    get_session_history=lambda sid: BrainctlChatMessageHistory(session_id=sid),
)
```

### CrewAI
```python
from agentmemory.integrations.crewai import BrainctlStorage
crew = Crew(
    memory=True,
    short_term_memory=ShortTermMemory(storage=BrainctlStorage("short-term")),
    long_term_memory=LongTermMemory(storage=BrainctlStorage("long-term")),
)
```

Both use brain.db, zero extra infrastructure, full Brain API accessible.

## Test plan
- [x] 16 new tests (mocked framework imports — runs without langchain/crewai installed)
- [x] Full suite: 1284 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)