### PR TITLE
fix(docs): bump tool count 194 -> 196 to unblock main CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Published as `brainctl` on PyPI (v1.1.2).
 ## Key Paths
 - **DB:** `db/brain.db` (WAL mode, foreign keys ON)
 - **CLI:** `bin/brainctl` — main CLI entry
-- **MCP server:** `bin/brainctl-mcp` — stdio MCP server (194 tools). Run with `python3`
+- **MCP server:** `bin/brainctl-mcp` — stdio MCP server (196 tools). Run with `python3`
 - **Source:** `src/agentmemory/` — Python package
 - **Config:** `config/` — quiet hours, consolidation schedules
 - **Agents:** `agents/` — per-agent config (pipeline, engram, etc.)

--- a/MCP_SERVER.md
+++ b/MCP_SERVER.md
@@ -42,7 +42,7 @@ Add to `.vscode/mcp.json` or User Settings:
 docker run -v ~/.agentmemory:/data -e BRAIN_DB=/data/brain.db ghcr.io/yourorg/brainctl-mcp
 ```
 
-## Available Tools (194)
+## Available Tools (196)
 
 | Tool | Description |
 |------|-------------|
@@ -100,7 +100,7 @@ docker run -v ~/.agentmemory:/data -e BRAIN_DB=/data/brain.db ghcr.io/yourorg/br
 
 ## Which Tools Do I Need?
 
-194 tools is overwhelming. Most agents need ~15 on a daily basis. Here's how to find what you need.
+196 tools is overwhelming. Most agents need ~15 on a daily basis. Here's how to find what you need.
 
 ### Tier 1: Essential (daily use)
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ brainctl stats
 }
 ```
 
-194 tools available. See [MCP_SERVER.md](MCP_SERVER.md) for the full list and a decision tree showing which tools to use when.
+196 tools available. See [MCP_SERVER.md](MCP_SERVER.md) for the full list and a decision tree showing which tools to use when.
 
 ## The Drop-In Pattern
 
@@ -326,7 +326,7 @@ docker run -v ./data:/data brainctl brainctl stats     # CLI
 |-----|---------------|
 | [Agent Onboarding Guide](docs/AGENT_ONBOARDING.md) | Step-by-step integration for agents |
 | [Agent Instructions](docs/AGENT_INSTRUCTIONS.md) | Copy-paste blocks for MCP, CLI, Python agents |
-| [MCP Server Reference](MCP_SERVER.md) | 194 tools with decision tree |
+| [MCP Server Reference](MCP_SERVER.md) | 196 tools with decision tree |
 | [Architecture](ARCHITECTURE.md) | Technical deep-dive |
 | [Cognitive Protocol](COGNITIVE_PROTOCOL.md) | The Orient-Work-Record pattern |
 | [Examples](examples/) | Runnable scripts (quickstart, lifecycle, multi-agent) |

--- a/docs/blog-persistent-memory.md
+++ b/docs/blog-persistent-memory.md
@@ -98,7 +98,7 @@ If you're using Claude Desktop, VS Code, or Cursor, brainctl ships an MCP server
 {"mcpServers": {"brainctl": {"command": "brainctl-mcp"}}}
 ```
 
-194 tools covering memory, events, entities, decisions, triggers, handoffs, consolidation, affect tracking, and more. But you don't need to learn all 194 — the [MCP docs](https://github.com/TSchonleber/brainctl/blob/main/MCP_SERVER.md) include a decision tree showing which ~15 tools you actually need.
+196 tools covering memory, events, entities, decisions, triggers, handoffs, consolidation, affect tracking, and more. But you don't need to learn all 196 — the [MCP docs](https://github.com/TSchonleber/brainctl/blob/main/MCP_SERVER.md) include a decision tree showing which ~15 tools you actually need.
 
 ## Framework Integrations
 

--- a/docs/show-hn-draft.md
+++ b/docs/show-hn-draft.md
@@ -26,7 +26,7 @@ Key technical decisions:
 - Three-tier routing (skip/cache/full-index) inspired by D-MEM (Song & Xin 2025, arXiv 2603.14597)
 - Half-life decay per category — integration details fade in a month, identity persists for a year
 - Bayesian confidence scoring with alpha/beta tracking
-- MCP server included (194 tools for Claude Desktop / VS Code)
+- MCP server included (196 tools for Claude Desktop / VS Code)
 - LangChain and CrewAI adapters included
 
 Python 3.11+, MIT licensed, zero dependencies for core.

--- a/plugins/eliza/brainctl/README.md
+++ b/plugins/eliza/brainctl/README.md
@@ -134,7 +134,7 @@ eliza --character=examples/trader.character.json
 │   Eliza runtime  │ ◄─────────────────────► │   brainctl-mcp   │
 │                  │                         │   (Python)       │
 │  ┌─────────────┐ │                         │                  │
-│  │ Plugin      │ │                         │  194 tools over  │
+│  │ Plugin      │ │                         │  196 tools over  │
 │  │  - actions  │ │                         │  SQLite FTS5 +   │
 │  │  - provider │ │                         │  sqlite-vec +    │
 │  │  - service  │ │                         │  knowledge graph │


### PR DESCRIPTION
## Summary

**Fixes main CI.** PR #70 added two first-class MCP tools (`agent_orient`, `agent_wrap_up`) bringing the total from 194 → 196, but didn't update any of the docs that reference the count. The `scripts/check_docs.py` guard (and the `test_docs_check.py::test_docs_match_implementation` test) started failing on main immediately after #70 merged:

```
MCP tools in mcp_server.py: 196

DOCS DRIFT DETECTED:
  ✗ MCP_SERVER.md says 194 tools, but mcp_server.py has 196.
    Update the header: ## Available Tools (196)
```

## What changed

Seven stale `194` references across six files:

| File | References |
|---|---|
| **`MCP_SERVER.md`** | `## Available Tools (194)` → `(196)` + prose "194 tools is overwhelming" → "196" |
| **`README.md`** | Body "194 tools available" + docs table entry |
| `CLAUDE.md` | Project instructions |
| `docs/show-hn-draft.md` | Draft copy |
| `docs/blog-persistent-memory.md` | Two body references |
| `plugins/eliza/brainctl/README.md` | ASCII architecture diagram |

Only `MCP_SERVER.md` and `README.md` are validated by `scripts/check_docs.py`, but I fixed the other five too so everything stays consistent.

## Verification (locally, against rebased `main`)

```
$ python3 scripts/check_docs.py
MCP tools in mcp_server.py: 196
MCP_SERVER.md: OK (196 tools)
All doc counts match implementation. ✓

$ python3 -m pytest tests/
1345 passed, 1 skipped in 208.69s

$ grep -rn '\b194\b' --include='*.md' --include='*.py' .
(no output)
```

Full test suite clean. Zero stray `194` references remain.

## Why this wasn't caught in #70

I ran `python3 -m py_compile` on `mcp_server.py` and a direct `Brain.orient()/wrap_up()` smoke test before merging #70, but didn't install the `mcp` Python package or run `scripts/check_docs.py` / `pytest tests/` locally. Those checks are CI-only.

The lesson for future integrations: before merging anything that adds MCP tools, run `python3 scripts/check_docs.py` (cheap, catches this exact class of drift). Added to my mental checklist.

## Test plan

- [x] `scripts/check_docs.py` passes locally
- [x] `pytest tests/test_docs_check.py` passes locally  
- [x] Full `pytest tests/` passes (1345 passed, 1 pre-existing skip)
- [x] `grep -rn '\b194\b'` returns zero matches
- [ ] CI green on main after this merges

https://claude.ai/code/session_01DAPZpUpMbpkHFPThtdBZ9h