### PR TITLE
Add cursor + openclaw plugins, trading roadmap, crypto-native placeholders

### DIFF
--- a/plugins/TRADING_INTEGRATIONS.md
+++ b/plugins/TRADING_INTEGRATIONS.md
@@ -1,0 +1,203 @@
+# brainctl — Trading & Crypto Agent Integrations Roadmap
+
+brainctl is a persistent-memory substrate for AI agents: a SQLite-backed
+brain with FTS5 search, optional vector recall, a knowledge graph, and
+session handoffs. This document tracks the integrations we ship, the
+ones we plan to ship, and the ones we've consciously left out.
+
+The focus is **crypto-native agent frameworks** and **serious trading
+bots**, because brainctl-launch is gearing up for a public launch in
+that space. General-purpose agent frameworks (LangGraph, CrewAI, etc.)
+are lower priority and tracked separately at the bottom.
+
+---
+
+## Current coverage
+
+| Plugin | Type | Pattern | Status |
+|---|---|---|---|
+| [`claude-code`](claude-code/brainctl/README.md) | Coding agent | Hook + skill | shipped |
+| [`codex`](codex/brainctl/README.md) | Coding agent | MCP installer | shipped |
+| [`cursor`](cursor/brainctl/README.md) | Coding agent | MCP installer + rules file | shipped |
+| [`openclaw`](openclaw/brainctl/README.md) | Coding agent | Workspace skill injection | shipped |
+| [`eliza`](eliza/brainctl/README.md) | Agent framework | TS plugin package | shipped |
+| [`hermes`](hermes/brainctl/README.md) | Trading agent | Native | shipped |
+| [`freqtrade`](freqtrade/brainctl/README.md) | Trading bot | Strategy mixin | shipped |
+| [`jesse`](jesse/brainctl/README.md) | Trading bot | Strategy mixin | shipped |
+
+---
+
+## Three reusable integration patterns
+
+Every plugin brainctl ships falls into one of three shapes. New plugins
+should reuse one of these patterns rather than inventing a new one.
+
+### 1. Strategy / Actor mixin (Python base class)
+
+The host framework (freqtrade, jesse) defines a strategy base class.
+brainctl ships a mixin that users multiply-inherit from. Lifecycle
+methods like `bot_start`, `confirm_trade_entry`, `on_order_filled`, and
+`bot_stop` hand off to `Brain.orient()`, `Brain.log()`, `decision_add`,
+and `Brain.wrap_up()`.
+
+**Reference:** `plugins/freqtrade/brainctl/mixin.py`,
+`plugins/jesse/brainctl/mixin.py`.
+
+**Best for:** Python trading frameworks with a strategy/actor class
+users subclass (Hummingbot, NautilusTrader, OctoBot's tentacle system).
+
+### 2. MCP server installer
+
+The host is an MCP client (Claude Code, Codex, Cursor, Windsurf,
+Cline). brainctl ships an idempotent installer that merges a
+sentinel-wrapped `mcpServers.brainctl` block into the host's config
+file. The agent then calls brainctl's ~196 MCP tools natively.
+
+**Reference:** `plugins/codex/brainctl/install.py`,
+`plugins/cursor/brainctl/install.py`.
+
+**Best for:** Any coding agent or agent framework that speaks MCP.
+Also works as a universal bridge for frameworks that can spawn MCP
+servers as tools (Coinbase AgentKit via Python tooling layer, Rig via
+a thin wrapper, etc.).
+
+### 3. Hook / skill injection
+
+The host has no MCP, no subclassable strategy class, but does have a
+filesystem-level extension surface: shell hooks (Claude Code's
+`hooks/*.py`), workspace markdown injection (OpenClaw's
+`workspace/skills/`), or plain rule files (Cursor's `.cursor/rules/`).
+brainctl ships a template the installer copies into place.
+
+**Reference:** `plugins/claude-code/brainctl/hooks/`,
+`plugins/openclaw/brainctl/SKILL.md.template`.
+
+**Best for:** Agents that expose markdown/skill injection or
+shell-level lifecycle hooks but no programmatic tool API.
+
+---
+
+## Priority 1 — crypto-native agent frameworks
+
+Ordered by **launch leverage** — how many crypto-AI developers we
+reach per PR.
+
+| Plugin | Framework | Language | Pattern | Placeholder |
+|---|---|---|---|---|
+| [`coinbase-agentkit`](coinbase-agentkit/brainctl/README.md) | [CDP AgentKit](https://github.com/coinbase/agentkit) | TS + Py | MCP bridge + `BrainctlActionProvider` | yes |
+| [`virtuals-game`](virtuals-game/brainctl/README.md) | [Virtuals GAME SDK](https://whitepaper.virtuals.io) | TS + Py | Custom worker + function registry | yes |
+| [`rig`](rig/brainctl/README.md) | [Rig](https://rig.rs) | Rust | Native `brainctl-rig` crate | yes |
+| [`zerebro`](zerebro/brainctl/README.md) | [ZerePy](https://github.com/blorm-network/ZerePy) | TS | TS plugin package | yes |
+
+### Rationale
+
+- **Coinbase AgentKit** is Coinbase's official onchain-agent framework.
+  Every CDP tutorial, every Base hackathon, every "build an onchain
+  agent" guide points here. Winning this integration means brainctl
+  becomes the default memory layer for Coinbase-branded agent
+  tutorials. Highest reach per PR.
+- **Virtuals GAME SDK** powers the largest crypto-AI agent ecosystem
+  by market cap — Luna, aixbt, and the $VIRTUAL cohort. These agents
+  have long-running personalities but no shared memory across
+  sessions. brainctl is exactly the missing primitive.
+- **Rig** is the Rust-first LLM agent framework used by high-perf
+  crypto / MEV / arb bots that can't afford Python's GIL. A
+  `brainctl-rig` crate is the only path to those users.
+- **ZerePy** is the reference stack for the $ZEREBRO cohort — onchain,
+  TS-first, Twitter/Discord/Farcaster-native. Same audience profile as
+  brainctl-launch's target users.
+
+---
+
+## Priority 2 — pro-grade trading bots
+
+All three use the **strategy-mixin** pattern already proven by
+`freqtrade` and `jesse`.
+
+| Plugin | Bot | Audience | Placeholder |
+|---|---|---|---|
+| [`hummingbot`](hummingbot/brainctl/README.md) | [Hummingbot](https://github.com/hummingbot/hummingbot) | Retail MM + arb | yes |
+| [`nautilustrader`](nautilustrader/brainctl/README.md) | [NautilusTrader](https://nautilustrader.io) | Quant shops, HFT | yes |
+| [`octobot`](octobot/brainctl/README.md) | [OctoBot](https://github.com/Drakkar-Software/OctoBot) | Retail algo | yes |
+
+### Rationale
+
+- **Hummingbot** is the most-used open-source market-making /
+  arbitrage bot on CEXes and DEXes. Serious retail MMs run it and
+  need persistent decision logs across strategy restarts.
+- **NautilusTrader** is the serious-quant Rust-core / Python-API
+  platform — event-driven, high-frequency, gaining ground in crypto
+  quant shops. A `BrainctlActor` base class slots cleanly into its
+  Actor model.
+- **OctoBot** has a first-class tentacle plugin system and the biggest
+  install count of any open-source retail crypto bot outside
+  Hummingbot. A `brainctl_service` tentacle lets thousands of users
+  opt in with one click.
+
+---
+
+## Priority 3 — general agent frameworks
+
+Roadmap-only. No placeholder directories yet — these are
+lower-launch-leverage for a crypto-themed launch but we'll want them
+before a general-purpose 2.0 release.
+
+| Framework | Language | Likely pattern |
+|---|---|---|
+| [LangGraph](https://langchain-ai.github.io/langgraph/) | Py + TS | Tool wrapper + checkpoint store |
+| [CrewAI](https://www.crewai.com/) | Py | Tool wrapper + crew memory backend |
+| [AutoGen](https://microsoft.github.io/autogen/) | Py | Tool wrapper |
+| [Pydantic AI](https://ai.pydantic.dev/) | Py | Tool wrapper |
+| [Mastra](https://mastra.ai/) | TS | Tool + memory provider |
+| [Goose](https://block.github.io/goose/) | Rust | MCP installer |
+
+---
+
+## Deliberately skipped
+
+- **Devin** (Cognition / Coinbase-hosted) — cloud-only with no local
+  install surface. No MCP, no hook runtime, no filesystem we can
+  inject into. A "knowledge export" script was considered and dropped
+  because it's a one-shot dump, not a round-trippable integration.
+- **Bare exchange SDKs** (ccxt, python-binance, hyperliquid-python) —
+  wrong layer. brainctl integrates with *agents* that use exchanges,
+  not the exchange SDKs themselves.
+- **Unmaintained bots** (Gekko, Zenbot, Tribeca) — dead projects.
+- **Closed-source desks** (Tradingview Pine, Quantconnect LEAN cloud,
+  proprietary MM stacks) — no contribution surface.
+
+---
+
+## How new plugins get added
+
+1. **Pick a pattern.** Mixin, MCP installer, or hook/skill — don't
+   invent a fourth.
+2. **Copy the closest existing plugin** as a template:
+   - Mixin -> `plugins/freqtrade/brainctl/` or
+     `plugins/jesse/brainctl/`
+   - MCP installer -> `plugins/codex/brainctl/` or
+     `plugins/cursor/brainctl/`
+   - Hook/skill -> `plugins/claude-code/brainctl/` or
+     `plugins/openclaw/brainctl/`
+3. **Ship the four required files** at minimum: `plugin.yaml`,
+   `install.py` (or equivalent), one template file, `README.md`.
+4. **Bump version.** Placeholders use `0.0.0-placeholder`. Shipped
+   plugins start at `0.1.0` and follow semver.
+5. **Update this doc.** Move the plugin's row from "placeholder" to
+   the appropriate "shipped" table.
+6. **PR.** One plugin per PR; core brainctl changes go in a separate
+   PR.
+
+---
+
+## Versioning
+
+- `0.0.0-placeholder` — directory exists, `plugin.yaml` has
+  `status: placeholder`, README explains the planned shape, no
+  executable code.
+- `0.1.0` — first functional implementation.
+- `0.2.0+` — feature adds or breaking changes, follows semver.
+
+The `status` field in `plugin.yaml` is the source of truth for
+placeholder vs shipped — tooling can grep for `status: placeholder` to
+hide incomplete plugins from install listings.

--- a/plugins/coinbase-agentkit/brainctl/README.md
+++ b/plugins/coinbase-agentkit/brainctl/README.md
@@ -1,0 +1,44 @@
+# brainctl x Coinbase AgentKit
+
+> **Status:** Placeholder — not yet implemented. Tracked in
+> [`plugins/TRADING_INTEGRATIONS.md`](../../TRADING_INTEGRATIONS.md#priority-1--crypto-native-agent-frameworks).
+
+## Why this integration matters
+
+[Coinbase AgentKit](https://github.com/coinbase/agentkit) is Coinbase's
+official framework for onchain AI agents: wallets, onramp, DEX swaps,
+ERC-20 / ERC-721 / ERC-1155 ops, and gasless transactions via the
+Coinbase Developer Platform (CDP). It ships in TypeScript and Python
+and is the default recommendation in every CDP tutorial, Base
+hackathon, and "build an onchain agent" guide.
+
+Onchain agents running AgentKit today have no persistent memory
+across sessions — wallets persist, but the agent's reasoning,
+decisions, postmortems, and handoffs don't. brainctl is exactly
+that missing primitive.
+
+## Planned integration pattern
+
+Dual shape, mirroring AgentKit's own TS + Py split:
+
+- **Python:** a native `BrainctlActionProvider` that extends
+  `coinbase_agentkit.action_providers.ActionProvider` and registers
+  `orient`, `memory_add`, `decision_add`, `search`, and `wrap_up` as
+  AgentKit Actions. Users add it to their `AgentKit` instance
+  alongside `wallet_action_provider` and friends.
+- **TypeScript:** use the existing **MCP installer pattern**
+  (`plugins/codex/brainctl/install.py`) to register `brainctl-mcp`
+  as an MCP server in the user's AgentKit TS agent config, letting
+  the agent invoke brainctl's tools via MCP.
+
+## Upstream
+
+- https://github.com/coinbase/agentkit
+- https://docs.cdp.coinbase.com/agentkit/docs/welcome
+
+## Contributing
+
+PRs welcome. Use `plugins/codex/brainctl/` (MCP installer) and
+`plugins/jesse/brainctl/mixin.py` (native Python class) as templates.
+Match the shape spelled out in
+[`plugins/TRADING_INTEGRATIONS.md`](../../TRADING_INTEGRATIONS.md).

--- a/plugins/coinbase-agentkit/brainctl/plugin.yaml
+++ b/plugins/coinbase-agentkit/brainctl/plugin.yaml
@@ -1,0 +1,6 @@
+name: brainctl
+version: 0.0.0-placeholder
+status: placeholder
+description: "PLACEHOLDER — brainctl integration for Coinbase CDP AgentKit. Not yet implemented. See plugins/TRADING_INTEGRATIONS.md for the roadmap."
+pip_dependencies: []
+requires_env: []

--- a/plugins/cursor/brainctl/README.md
+++ b/plugins/cursor/brainctl/README.md
@@ -1,0 +1,114 @@
+# brainctl plugin for Cursor
+
+Give [Cursor](https://cursor.com) persistent memory via [brainctl](https://github.com/TSchonleber/brainctl) — SQLite-backed long-term memory with FTS5 search, optional vector recall, a knowledge graph, and session handoffs. One file, zero servers, zero API keys.
+
+> Your Cursor agent forgets everything between chats. This plugin fixes that.
+
+## What it gives you
+
+Cursor discovers any MCP server listed in `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project-local) and exposes every tool it publishes to the agent. This plugin wires `brainctl-mcp` in as a Cursor MCP server, so the agent gets the full brainctl tool surface (196 tools) — remember, search, think, decide, log, entity ops, handoffs, affect tracking, and the rest.
+
+Pair that with the included `.cursor/rules/brainctl.mdc` template and your Cursor sessions will:
+
+- **Orient on start** — pull the last handoff packet, recent events, and task-relevant memories before doing anything
+- **Accumulate memory while working** — durable facts via `memory_add`, decisions via `decision_add`, events via `event_add`
+- **Wrap up on end** — write a handoff packet with goal / current_state / open_loops / next_step so the next session can resume cleanly
+
+## Prerequisites
+
+```bash
+pip install 'brainctl[mcp]>=1.3.0'
+```
+
+That puts `brainctl-mcp` on your PATH. Cursor will spawn it as a subprocess whenever a session starts.
+
+Optional: `pip install 'brainctl[vec]'` + `ollama pull nomic-embed-text` for vector recall.
+
+## Install
+
+From a cloned brainctl repo:
+
+```bash
+python3 plugins/cursor/brainctl/install.py              # install (global, ~/.cursor/mcp.json)
+python3 plugins/cursor/brainctl/install.py --project    # install into ./.cursor/mcp.json
+python3 plugins/cursor/brainctl/install.py --dry        # preview only, no writes
+python3 plugins/cursor/brainctl/install.py --uninstall
+```
+
+The installer merges an idempotent `brainctl` entry into the top-level `mcpServers` object of `~/.cursor/mcp.json` (or `$CURSOR_HOME/mcp.json`, or a project-local `./.cursor/mcp.json` with `--project`). Existing MCP servers and other top-level keys are left untouched. A `.brainctl.bak` backup is written before any edit so uninstall is a clean removal.
+
+If you'd rather paste the config yourself, run:
+
+```bash
+python3 plugins/cursor/brainctl/install.py --print
+```
+
+and drop the output into your `mcp.json`.
+
+## Project instructions
+
+The MCP server gives Cursor the *ability* to use brainctl, but you still need to tell it *when*. Copy `rules.mdc.template` into `.cursor/rules/brainctl.mdc` at the root of any project where you want brainctl-backed memory:
+
+```bash
+mkdir -p /path/to/your/project/.cursor/rules
+cp plugins/cursor/brainctl/rules.mdc.template /path/to/your/project/.cursor/rules/brainctl.mdc
+```
+
+Cursor auto-loads `.cursor/rules/*.mdc` files with `alwaysApply: true` on every session, so the brainctl lifecycle instructions become part of every chat without any further configuration.
+
+## Config
+
+The MCP server entry takes no config beyond the `BRAIN_DB` environment variable (optional — defaults to `~/agentmemory/db/brain.db`). Every other option lives in the brain itself via `brainctl config`.
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `BRAIN_DB` | `~/agentmemory/db/brain.db` | Path to the SQLite brain file |
+| `BRAINCTL_AGENT_ID` | `cursor` | Agent ID recorded on every write |
+| `CURSOR_HOME` | `~/.cursor` | Override directory used to locate `mcp.json` |
+
+## What the installed config looks like
+
+```json
+{
+  "mcpServers": {
+    "brainctl": {
+      "command": "brainctl-mcp",
+      "args": [],
+      "env": {
+        "BRAINCTL_AGENT_ID": "cursor"
+      }
+    }
+  }
+}
+```
+
+## Tool surface
+
+Once installed, Cursor gets 196 brainctl tools including:
+
+| Tool | Purpose |
+|------|---------|
+| `memory_add` | Store a durable fact |
+| `memory_search` | FTS5 full-text recall |
+| `search` | Unified search across memories, events, entities |
+| `think` | Spreading-activation recall across the knowledge graph |
+| `decision_add` | Record a decision with rationale |
+| `event_add` | Append to the event stream |
+| `entity_create` / `entity_observe` / `entity_relate` | Knowledge-graph ops |
+| `handoff_latest` / `handoff_add` | Session handoffs |
+| `agent_orient` / `agent_wrap_up` | Native session bookends (new in v1.3.0) |
+| `affect_log` / `affect_check` / `affect_classify` | Affect tracking |
+| `pagerank` / `zoom_in` / `zoom_out` / `temporal_map` | Graph / temporal navigation |
+
+See [`MCP_SERVER.md`](../../../MCP_SERVER.md) for the full list and decision tree.
+
+## Troubleshooting
+
+- **"command not found: brainctl-mcp"** — install with the `[mcp]` extra: `pip install 'brainctl[mcp]'`. A plain `pip install brainctl` doesn't include the MCP server entry point.
+- **Cursor doesn't see the tools** — open Cursor Settings → MCP and check the `brainctl` row. If it's red, click through to inspect the stderr log for the subprocess; most failures are a missing `brainctl-mcp` on PATH or a bad `BRAIN_DB` path.
+- **Tools listed but the agent ignores them** — make sure `.cursor/rules/brainctl.mdc` exists at the project root and still has `alwaysApply: true` in its frontmatter. Without the rules file Cursor has the tools but no instructions on when to call them.
+- **Wrong brain.db location** — set `BRAIN_DB` in the `env` map of the MCP entry, or export it in the shell you launched Cursor from.
+
+## License
+
+MIT. See the main [brainctl](https://github.com/TSchonleber/brainctl) repo.

--- a/plugins/cursor/brainctl/install.py
+++ b/plugins/cursor/brainctl/install.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Install the brainctl MCP server into Cursor's mcp.json.
+
+Merges an idempotent `brainctl` entry into the top-level `mcpServers`
+object of `~/.cursor/mcp.json` (or `$CURSOR_HOME/mcp.json`, or a
+project-local `./.cursor/mcp.json` with `--project`). The merge touches
+only the `brainctl` key so the rest of the user's Cursor MCP
+configuration is left alone.
+
+Usage:
+    python3 plugins/cursor/brainctl/install.py              # install (global)
+    python3 plugins/cursor/brainctl/install.py --project    # install into ./.cursor/mcp.json
+    python3 plugins/cursor/brainctl/install.py --path PATH  # explicit target
+    python3 plugins/cursor/brainctl/install.py --dry        # preview, no write
+    python3 plugins/cursor/brainctl/install.py --print      # print entry only
+    python3 plugins/cursor/brainctl/install.py --uninstall  # remove entry
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+ENTRY: dict = {
+    "command": "brainctl-mcp",
+    "args": [],
+    "env": {"BRAINCTL_AGENT_ID": "cursor"},
+}
+
+
+def global_config_path() -> Path:
+    base = os.environ.get("CURSOR_HOME")
+    if base:
+        return Path(base).expanduser() / "mcp.json"
+    return Path.home() / ".cursor" / "mcp.json"
+
+
+def project_config_path() -> Path:
+    return Path.cwd() / ".cursor" / "mcp.json"
+
+
+def read_config(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    raw = path.read_text(encoding="utf-8").strip()
+    if not raw:
+        return {}
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise SystemExit(f"[brainctl] {path} is not a JSON object; refusing to edit.")
+    return data
+
+
+def merge(existing: dict) -> dict:
+    """Return a copy of existing with the brainctl entry set under mcpServers."""
+    out = dict(existing)
+    servers = dict(out.get("mcpServers") or {})
+    servers["brainctl"] = ENTRY
+    out["mcpServers"] = servers
+    return out
+
+
+def remove_entry(existing: dict) -> dict:
+    """Return a copy with the brainctl entry removed; drop mcpServers if empty."""
+    out = dict(existing)
+    servers = dict(out.get("mcpServers") or {})
+    if "brainctl" not in servers:
+        return out
+    servers.pop("brainctl", None)
+    if servers:
+        out["mcpServers"] = servers
+    else:
+        out.pop("mcpServers", None)
+    return out
+
+
+def serialize(data: dict) -> str:
+    return json.dumps(data, indent=2) + "\n"
+
+
+def backup(path: Path) -> Path | None:
+    if not path.exists():
+        return None
+    bak = path.with_suffix(path.suffix + ".brainctl.bak")
+    shutil.copy2(path, bak)
+    return bak
+
+
+def preflight_brainctl_mcp() -> None:
+    """Warn (do not fail) if brainctl-mcp isn't on PATH."""
+    if shutil.which("brainctl-mcp") is None:
+        print(
+            "[brainctl] WARNING: `brainctl-mcp` not found on PATH.\n"
+            "           Cursor will fail to start the server until you run:\n"
+            "               pip install 'brainctl[mcp]>=1.3.0'",
+            file=sys.stderr,
+        )
+
+
+def resolve_path(args: argparse.Namespace) -> Path:
+    if args.path:
+        return Path(args.path).expanduser()
+    if args.project:
+        return project_config_path()
+    return global_config_path()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Install brainctl MCP into Cursor.")
+    parser.add_argument("--project", action="store_true",
+                        help="Target ./.cursor/mcp.json instead of the global config.")
+    parser.add_argument("--path", default=None,
+                        help="Explicit path to the mcp.json file to edit.")
+    parser.add_argument("--dry", action="store_true", help="Preview changes without writing.")
+    parser.add_argument("--print", dest="print_only", action="store_true",
+                        help="Print the JSON entry to stdout and exit.")
+    parser.add_argument("--uninstall", action="store_true",
+                        help="Remove the brainctl entry from mcp.json.")
+    args = parser.parse_args()
+
+    if args.print_only:
+        sys.stdout.write(json.dumps({"mcpServers": {"brainctl": ENTRY}}, indent=2) + "\n")
+        return 0
+
+    path = resolve_path(args)
+    existing = read_config(path)
+
+    if args.uninstall:
+        servers = (existing.get("mcpServers") or {}) if isinstance(existing, dict) else {}
+        if "brainctl" not in servers:
+            print(f"[brainctl] no brainctl entry found in {path} — nothing to do.")
+            return 0
+        new_data = remove_entry(existing)
+        if args.dry:
+            print(f"[brainctl] --dry: would rewrite {path} without the brainctl entry.")
+            return 0
+        bak = backup(path)
+        path.write_text(serialize(new_data), encoding="utf-8")
+        print(f"[brainctl] removed brainctl entry from {path}"
+              + (f" (backup: {bak})" if bak else ""))
+        return 0
+
+    preflight_brainctl_mcp()
+    new_data = merge(existing)
+
+    if new_data == existing:
+        print(f"[brainctl] {path} already up to date.")
+        return 0
+
+    if args.dry:
+        print(f"[brainctl] --dry: would write {path}:")
+        print("---")
+        sys.stdout.write(serialize(new_data))
+        print("---")
+        return 0
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    bak = backup(path)
+    path.write_text(serialize(new_data), encoding="utf-8")
+    print(f"[brainctl] installed brainctl MCP entry into {path}"
+          + (f" (backup: {bak})" if bak else ""))
+    print("[brainctl] next: copy plugins/cursor/brainctl/rules.mdc.template "
+          "into your project's .cursor/rules/brainctl.mdc to enable session bookends.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/cursor/brainctl/plugin.yaml
+++ b/plugins/cursor/brainctl/plugin.yaml
@@ -1,0 +1,7 @@
+name: brainctl
+version: 0.1.0
+description: "Cursor persistent memory via brainctl MCP server. Installs brainctl into ~/.cursor/mcp.json and ships a Cursor rules template (.cursor/rules/brainctl.mdc) for session bookends."
+pip_dependencies:
+  - "brainctl[mcp]>=1.3.0"
+requires_env:
+  - BRAIN_DB   # optional — defaults to ~/agentmemory/db/brain.db

--- a/plugins/cursor/brainctl/rules.mdc.template
+++ b/plugins/cursor/brainctl/rules.mdc.template
@@ -1,0 +1,74 @@
+---
+description: "Use brainctl for persistent memory across Cursor sessions"
+alwaysApply: true
+---
+
+<!--
+  brainctl memory instructions for Cursor.
+  Drop this into .cursor/rules/brainctl.mdc at your project root.
+  Cursor auto-loads .mdc rules with alwaysApply: true on every session.
+-->
+
+## Persistent memory (brainctl)
+
+This project uses [brainctl](https://github.com/TSchonleber/brainctl) for persistent
+memory across Cursor sessions. brainctl is available as an MCP server — its tools
+are prefixed with `mcp__brainctl__` in your tool list.
+
+### On session start
+
+Before taking any other action, orient yourself:
+
+1. Call `mcp__brainctl__agent_orient` with a brief summary of the task you're
+   about to work on. This returns the latest handoff packet, recent events,
+   and task-relevant memories from previous sessions.
+2. Use `mcp__brainctl__search` with keywords from the task to pull additional
+   context if the orient snapshot isn't enough.
+
+Treat the orient output as authoritative context. If it conflicts with what
+you think you know, trust the brain and flag the discrepancy.
+
+### During work
+
+As durable information surfaces, write it back:
+
+- `mcp__brainctl__memory_add` — store a long-term fact. Pick a category:
+  `convention`, `decision`, `environment`, `integration`, `lesson`,
+  `preference`, `project`, or `user`. Add tags for discoverability.
+- `mcp__brainctl__decision_add` — record a decision with its rationale.
+  Future-you (and the next agent) will need to know *why*, not just *what*.
+- `mcp__brainctl__event_add` — append to the structured event stream for
+  notable things: test results, errors, observations, completed tasks.
+- `mcp__brainctl__entity_create` / `_observe` / `_relate` — build up the
+  knowledge graph when you encounter named things (services, people, files).
+
+Skip writes for ephemeral chatter, intermediate scratchwork, and anything
+that's already obvious from reading the code.
+
+### Search strategy
+
+- `mcp__brainctl__search` — general-purpose recall. Start here.
+- `mcp__brainctl__memory_search` — FTS5 full-text over stored memories only.
+- `mcp__brainctl__think` — spreading-activation recall across the knowledge
+  graph. Use when you want related concepts, not just literal string matches.
+
+### On session end
+
+Call `mcp__brainctl__agent_wrap_up` with a short packet covering:
+
+- **goal**: what you were trying to accomplish
+- **current_state**: where things stand now
+- **open_loops**: unfinished work, known issues, pending questions
+- **next_step**: the single most useful thing the next session should do first
+
+This handoff is the *only* thing the next session will see before it calls
+`agent_orient`. Make it tight, honest, and actionable.
+
+### Do not
+
+- Store secrets, API keys, passwords, or credentials in memory — brain.db
+  is plaintext SQLite.
+- Mirror transient build output or test logs as memories. Use `event_add`
+  for those instead.
+- Duplicate facts that are already in the code. Memory is for things git
+  blame can't tell you.

--- a/plugins/hummingbot/brainctl/README.md
+++ b/plugins/hummingbot/brainctl/README.md
@@ -1,0 +1,45 @@
+# brainctl x Hummingbot
+
+> **Status:** Placeholder — not yet implemented. Tracked in
+> [`plugins/TRADING_INTEGRATIONS.md`](../../TRADING_INTEGRATIONS.md#priority-2--pro-grade-trading-bots).
+
+## Why this integration matters
+
+[Hummingbot](https://github.com/hummingbot/hummingbot) is the
+most-used open-source market-making and arbitrage bot for crypto
+exchanges (CEX + DEX). Every serious retail market maker runs
+it. Hummingbot strategies churn through thousands of orders per day
+but have no persistent reasoning log across restarts — when a
+strategy crashes, its "why did I do that" context dies with it.
+
+brainctl gives Hummingbot users a queryable decision log that
+survives restarts, forks, and backtests.
+
+## Planned integration pattern
+
+**Strategy mixin**, same shape as `plugins/freqtrade/brainctl/mixin.py`.
+
+Ship a `BrainctlStrategyMixin` users multiply-inherit into their
+Hummingbot strategy:
+
+```python
+class MyStrategy(BrainctlStrategyMixin, ScriptStrategyBase):
+    ...
+```
+
+The mixin wires:
+
+- `on_start` -> `Brain.orient()`
+- `on_stop` -> `Brain.wrap_up()`
+- `on_tick` (rate-limited) -> periodic status writes
+- `did_fill_order` -> `Brain.log()` + `decision_add`
+
+## Upstream
+
+- https://github.com/hummingbot/hummingbot
+- https://hummingbot.org/docs
+
+## Contributing
+
+PRs welcome. Use `plugins/freqtrade/brainctl/mixin.py` as the
+template.

--- a/plugins/hummingbot/brainctl/plugin.yaml
+++ b/plugins/hummingbot/brainctl/plugin.yaml
@@ -1,0 +1,6 @@
+name: brainctl
+version: 0.0.0-placeholder
+status: placeholder
+description: "PLACEHOLDER — brainctl integration for Hummingbot via a BrainctlStrategyMixin. Not yet implemented. See plugins/TRADING_INTEGRATIONS.md for the roadmap."
+pip_dependencies: []
+requires_env: []

--- a/plugins/nautilustrader/brainctl/README.md
+++ b/plugins/nautilustrader/brainctl/README.md
@@ -1,0 +1,41 @@
+# brainctl x NautilusTrader
+
+> **Status:** Placeholder — not yet implemented. Tracked in
+> [`plugins/TRADING_INTEGRATIONS.md`](../../TRADING_INTEGRATIONS.md#priority-2--pro-grade-trading-bots).
+
+## Why this integration matters
+
+[NautilusTrader](https://nautilustrader.io) is a high-performance,
+event-driven algorithmic trading platform with a Rust core and
+Python API. It's the serious quant's choice — built for
+high-frequency, multi-venue, backtest/live parity — and has been
+gaining ground in crypto quant shops that outgrew Freqtrade and
+Jesse.
+
+Nautilus's Actor model is a clean fit for brainctl: every Actor
+already exposes `on_start` / `on_stop` / `on_event` lifecycle
+hooks that map 1:1 to brainctl's orient/log/wrap_up surface.
+
+## Planned integration pattern
+
+**Actor base class** — ship a `BrainctlActor` extending
+`nautilus_trader.common.actor.Actor` that users subclass instead of
+`Actor` directly. Wires:
+
+- `on_start` -> `Brain.orient()`
+- `on_stop` -> `Brain.wrap_up()`
+- `on_event` -> `Brain.log()`
+- `on_order_filled` -> `decision_add` with the fill rationale
+
+Same pattern as `plugins/jesse/brainctl/mixin.py`, adapted to
+Nautilus's Actor API.
+
+## Upstream
+
+- https://github.com/nautechsystems/nautilus_trader
+- https://nautilustrader.io
+- https://docs.nautilustrader.io
+
+## Contributing
+
+PRs welcome. Use `plugins/jesse/brainctl/mixin.py` as the template.

--- a/plugins/nautilustrader/brainctl/plugin.yaml
+++ b/plugins/nautilustrader/brainctl/plugin.yaml
@@ -1,0 +1,6 @@
+name: brainctl
+version: 0.0.0-placeholder
+status: placeholder
+description: "PLACEHOLDER — brainctl integration for NautilusTrader via a BrainctlActor base class. Not yet implemented. See plugins/TRADING_INTEGRATIONS.md for the roadmap."
+pip_dependencies: []
+requires_env: []

--- a/plugins/octobot/brainctl/README.md
+++ b/plugins/octobot/brainctl/README.md
@@ -1,0 +1,42 @@
+# brainctl x OctoBot
+
+> **Status:** Placeholder — not yet implemented. Tracked in
+> [`plugins/TRADING_INTEGRATIONS.md`](../../TRADING_INTEGRATIONS.md#priority-2--pro-grade-trading-bots).
+
+## Why this integration matters
+
+[OctoBot](https://github.com/Drakkar-Software/OctoBot) is the
+biggest open-source retail crypto trading bot outside Hummingbot by
+install count, with a polished web UI and a first-class **tentacle**
+plugin system designed exactly for third-party integrations like
+this one. Shipping brainctl as a tentacle lets thousands of retail
+OctoBot users opt in with a one-click install from the tentacle
+manager.
+
+## Planned integration pattern
+
+**Tentacle package**. Ship a `brainctl_service` tentacle under
+OctoBot's `Services` category (or `Strategies`, TBD after reading
+the tentacle spec). The tentacle:
+
+- Subscribes to OctoBot's lifecycle channels
+  (`bot-started`, `bot-stopping`, `trade-executed`,
+  `evaluation-changed`).
+- Forwards each event to brainctl via `Brain.log()` /
+  `decision_add`.
+- Exposes a config panel for `BRAIN_DB` path + agent ID.
+
+Distributed via a tentacle JSON manifest so users install with
+`pip install -e` or OctoBot's tentacle manager.
+
+## Upstream
+
+- https://github.com/Drakkar-Software/OctoBot
+- https://www.octobot.cloud
+- https://developer-docs.octobot.online/pages/guides/developers/tentacles.html
+
+## Contributing
+
+PRs welcome. Use `plugins/freqtrade/brainctl/mixin.py` as the
+handler reference and OctoBot's tentacle template for the package
+shape.

--- a/plugins/octobot/brainctl/plugin.yaml
+++ b/plugins/octobot/brainctl/plugin.yaml
@@ -1,0 +1,6 @@
+name: brainctl
+version: 0.0.0-placeholder
+status: placeholder
+description: "PLACEHOLDER — brainctl integration for OctoBot via a brainctl_service tentacle package. Not yet implemented. See plugins/TRADING_INTEGRATIONS.md for the roadmap."
+pip_dependencies: []
+requires_env: []

--- a/plugins/openclaw/brainctl/AGENTS.md.snippet
+++ b/plugins/openclaw/brainctl/AGENTS.md.snippet
@@ -1,0 +1,15 @@
+## Persistent memory (brainctl)
+
+This workspace has persistent memory across sessions via **brainctl**, exposed
+to Pi as the `brainctl` CLI. Full usage lives in
+`skills/brainctl/SKILL.md` — read it before your first memory call.
+
+- **On task start:** run `brainctl --agent openclaw orient --project <p>` and
+  treat the output as authoritative prior context.
+- **During work:** capture durable facts with `memory add`, `decision add`,
+  `event add`, and the `entity` commands. Skip ephemeral chatter.
+- **On task end:** run `brainctl --agent openclaw wrap-up` with goal,
+  current-state, open-loops, and next-step so the next session can resume.
+
+Never store secrets, credentials, or transient log output in brainctl — use
+`event add` for logs and keep `brain.db` free of sensitive material.

--- a/plugins/openclaw/brainctl/README.md
+++ b/plugins/openclaw/brainctl/README.md
@@ -1,0 +1,68 @@
+# brainctl plugin for OpenClaw
+
+Give [OpenClaw](https://openclaw.ai)'s Pi agent persistent memory via [brainctl](https://github.com/TSchonleber/brainctl) — SQLite-backed long-term memory with FTS5 search, optional vector recall, a knowledge graph, and session handoffs.
+
+> Pi forgets everything between sessions. This plugin fixes that.
+
+## Integration shape
+
+OpenClaw auto-injects three prompt files from the workspace root into every Pi session — `AGENTS.md`, `SOUL.md`, and `TOOLS.md` — and loads skills from `<workspace>/skills/<skill-name>/SKILL.md`. This plugin uses that surface:
+
+- It drops a `brainctl` skill into `<workspace>/skills/brainctl/SKILL.md` so Pi has a detailed reference for the CLI on hand.
+- It merges a short sentinel-wrapped "Persistent memory" section into `<workspace>/AGENTS.md` so every session starts knowing memory exists and where to look for usage details.
+
+This plugin deliberately does **not** install an MCP server and **does not touch** the root `~/.openclaw/openclaw.json`, nor does it register anything with OpenClaw's npm plugin system. Pi invokes brainctl by shelling out to the plain `brainctl` CLI in its shell.
+
+If and when OpenClaw ships first-class MCP support, this plugin will grow an MCP install path alongside the skill path — the same shape already used by `plugins/cursor/` and `plugins/codex/`.
+
+## Prerequisites
+
+```bash
+pip install 'brainctl>=1.2.0'
+```
+
+That puts the `brainctl` CLI on PATH for whatever shell OpenClaw spawns Pi in.
+
+Optional: `pip install 'brainctl[vec]'` + `ollama pull nomic-embed-text` for vector recall.
+
+## Install
+
+From a cloned brainctl repo:
+
+```bash
+python3 plugins/openclaw/brainctl/install.py                    # install
+python3 plugins/openclaw/brainctl/install.py --dry              # preview only
+python3 plugins/openclaw/brainctl/install.py --uninstall        # remove
+python3 plugins/openclaw/brainctl/install.py --path /custom/workspace
+```
+
+The default workspace is `~/.openclaw/workspace` (or `$OPENCLAW_HOME/workspace` if set).
+
+## What the installer does
+
+- Copies `SKILL.md.template` to `<workspace>/skills/brainctl/SKILL.md`, creating parent directories as needed.
+- Merges `AGENTS.md.snippet` into `<workspace>/AGENTS.md` wrapped in HTML-comment sentinels (`<!-- >>> brainctl >>> -->` / `<!-- <<< brainctl <<< -->`) so future runs update the block in place.
+- Backs up any pre-existing `AGENTS.md` to `AGENTS.md.brainctl.bak` before overwriting.
+- Idempotent: rerunning with no changes produces no writes and prints `already up to date`.
+- Leaves every other file in your OpenClaw workspace untouched.
+
+## Config
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `BRAIN_DB` | `~/agentmemory/db/brain.db` | Path to the SQLite brain file |
+| `BRAINCTL_AGENT_ID` | `openclaw` | Agent ID recorded on every write |
+| `OPENCLAW_HOME` | `~/.openclaw` | OpenClaw root — workspace is `$OPENCLAW_HOME/workspace` |
+
+All other brainctl options live inside the brain itself via `brainctl config`.
+
+## Troubleshooting
+
+- **Pi doesn't reach for brainctl** — open `<workspace>/AGENTS.md` and confirm it still contains the `<!-- >>> brainctl >>> -->` block. If it's missing, rerun the installer. OpenClaw only injects what's in `AGENTS.md`; if the block is gone, Pi has no reason to know memory exists.
+- **`brainctl: command not found` in Pi's shell** — install brainctl into the Python environment OpenClaw's shell inherits: `pip install 'brainctl>=1.2.0'`. The skill file assumes `brainctl` is on PATH for every shell Pi spawns.
+- **Pi writes to memory but never reads from it** — that usually means the AGENTS.md snippet was stripped or never installed. The snippet is what tells Pi *when* to call `orient`; without it, Pi treats brainctl as write-only. Rerun the installer.
+- **Wrong `brain.db` location** — set `BRAIN_DB` in the environment OpenClaw spawns Pi in. brainctl defaults to `~/agentmemory/db/brain.db`.
+
+## License
+
+MIT. See the main [brainctl](https://github.com/TSchonleber/brainctl) repository for the full license text.

--- a/plugins/openclaw/brainctl/SKILL.md.template
+++ b/plugins/openclaw/brainctl/SKILL.md.template
@@ -1,0 +1,94 @@
+---
+name: brainctl
+description: "Persistent memory across OpenClaw sessions via the brainctl CLI."
+---
+
+# brainctl skill
+
+brainctl is available as the `brainctl` CLI in Pi's shell. It is a
+SQLite-backed persistent memory system with FTS5 search, an optional vector
+index, a knowledge graph, and session handoffs. See
+<https://github.com/TSchonleber/brainctl> for the full reference.
+
+All commands in this skill default to `--agent openclaw`. Scope writes and
+reads to the active project with `--project <name>` whenever you know it.
+
+## On task start — orient
+
+Before doing anything else, pull prior context:
+
+```bash
+brainctl --agent openclaw orient --project <p>
+```
+
+This returns the latest handoff packet, recent events, and task-relevant
+memories from previous sessions. Treat the orient output as authoritative
+prior context. If it conflicts with what you think you know, trust the brain
+and flag the discrepancy.
+
+Follow up with targeted recall when orient alone is not enough:
+
+```bash
+brainctl --agent openclaw search "<keywords>" --project <p>
+brainctl --agent openclaw think "<concept>" --project <p>
+```
+
+`search` is literal FTS5. `think` is spreading-activation across the graph —
+reach for it when you want related concepts rather than string matches.
+
+## During work — capture durable facts
+
+As durable information surfaces, write it back. Skip ephemeral chatter,
+intermediate scratchwork, and anything already obvious from reading the code.
+
+```bash
+# Store a long-term fact. Category is one of:
+#   convention | decision | environment | integration |
+#   lesson     | preference | project    | user
+brainctl --agent openclaw memory add \
+  --category <cat> \
+  --content "<fact>" \
+  --tags <tag1,tag2> \
+  --project <p>
+
+# Record a decision with its rationale and outcome.
+brainctl --agent openclaw decision add \
+  --title "<short title>" \
+  --rationale "<why>" \
+  --outcome "<what it enables or blocks>" \
+  --project <p>
+
+# Append to the structured event stream (test results, errors, observations).
+brainctl --agent openclaw event add \
+  --type <test|error|observation|task> \
+  --content "<what happened>" \
+  --project <p>
+
+# Build up the knowledge graph for named things (services, files, people).
+brainctl --agent openclaw entity create --name "<name>" --kind <kind>
+brainctl --agent openclaw entity observe --name "<name>" --content "<observation>"
+brainctl --agent openclaw entity relate --src "<a>" --dst "<b>" --kind <relation>
+```
+
+## On task end — wrap up
+
+Before you stop, write a handoff packet. The next session reads this
+verbatim when it calls `orient`, so make it tight, honest, and actionable.
+
+```bash
+brainctl --agent openclaw wrap-up \
+  --project <p> \
+  --goal "<what you were trying to accomplish>" \
+  --current-state "<where things stand now>" \
+  --open-loops "<unfinished work, known issues, pending questions>" \
+  --next-step "<the single most useful thing to do first next time>"
+```
+
+## Do not
+
+- Do not store secrets, API keys, passwords, or credentials — `brain.db` is
+  plaintext SQLite.
+- Do not mirror transient build output or test logs as memories. Use
+  `event add` for those instead.
+- Do not duplicate facts that are already in the code. Memory is for things
+  git blame cannot tell you.

--- a/plugins/openclaw/brainctl/install.py
+++ b/plugins/openclaw/brainctl/install.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Install the brainctl skill + AGENTS.md snippet into an OpenClaw workspace.
+
+OpenClaw auto-injects `AGENTS.md`, `SOUL.md`, and `TOOLS.md` from the workspace
+root into every Pi session, and loads skills from
+`<workspace>/skills/<skill-name>/SKILL.md`. This installer uses that surface:
+it copies a `brainctl` skill file into `skills/brainctl/SKILL.md` and merges a
+short sentinel-wrapped "Persistent memory" section into the workspace
+`AGENTS.md` so Pi knows the memory skill exists and reaches for it.
+
+This is a filesystem installer, not an MCP installer. Pi invokes brainctl by
+shelling out to the `brainctl` CLI — no MCP server is registered, and the
+root `~/.openclaw/openclaw.json` is never touched.
+
+Usage:
+    python3 plugins/openclaw/brainctl/install.py              # install
+    python3 plugins/openclaw/brainctl/install.py --dry        # preview, no write
+    python3 plugins/openclaw/brainctl/install.py --uninstall  # remove skill + block
+    python3 plugins/openclaw/brainctl/install.py --path WORKSPACE
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+# HTML-comment sentinels so the block is invisible when AGENTS.md is rendered.
+SENTINEL_START = "<!-- >>> brainctl >>> -->"
+SENTINEL_END = "<!-- <<< brainctl <<< -->"
+
+HERE = Path(__file__).resolve().parent
+SKILL_TEMPLATE = HERE / "SKILL.md.template"
+AGENTS_SNIPPET = HERE / "AGENTS.md.snippet"
+
+
+def workspace_path(override: str | None) -> Path:
+    """Return the OpenClaw workspace dir, honoring --path and $OPENCLAW_HOME."""
+    if override:
+        return Path(override).expanduser()
+    base = os.environ.get("OPENCLAW_HOME")
+    if base:
+        return Path(base).expanduser() / "workspace"
+    return Path.home() / ".openclaw" / "workspace"
+
+
+def read_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def strip_block(text: str) -> str:
+    """Remove any existing sentinel-wrapped brainctl block, return the rest."""
+    if SENTINEL_START not in text:
+        return text
+    lines = text.splitlines(keepends=True)
+    out: list[str] = []
+    skipping = False
+    for line in lines:
+        if line.rstrip() == SENTINEL_START:
+            skipping = True
+            continue
+        if skipping:
+            if line.rstrip() == SENTINEL_END:
+                skipping = False
+            continue
+        out.append(line)
+    return "".join(out)
+
+
+def merge(existing: str, snippet_body: str) -> str:
+    """Return AGENTS.md with a single fresh sentinel-wrapped brainctl block appended."""
+    cleaned = strip_block(existing)
+    if cleaned and not cleaned.endswith("\n"):
+        cleaned += "\n"
+    if cleaned and not cleaned.endswith("\n\n"):
+        cleaned += "\n"
+    body = snippet_body.strip("\n")
+    block = f"{SENTINEL_START}\n{body}\n{SENTINEL_END}\n"
+    return cleaned + block
+
+
+def backup(path: Path) -> Path | None:
+    if not path.exists():
+        return None
+    bak = path.with_suffix(path.suffix + ".brainctl.bak")
+    shutil.copy2(path, bak)
+    return bak
+
+
+def preflight_brainctl() -> None:
+    """Warn (do not fail) if the `brainctl` CLI isn't on PATH."""
+    if shutil.which("brainctl") is None:
+        print(
+            "[brainctl] WARNING: `brainctl` not found on PATH.\n"
+            "           Pi will fail to shell out to the CLI until you run:\n"
+            "               pip install 'brainctl>=1.2.0'",
+            file=sys.stderr,
+        )
+
+
+def install(workspace: Path, dry: bool) -> int:
+    if not SKILL_TEMPLATE.exists():
+        print(f"[brainctl] missing template: {SKILL_TEMPLATE}", file=sys.stderr)
+        return 2
+    if not AGENTS_SNIPPET.exists():
+        print(f"[brainctl] missing snippet: {AGENTS_SNIPPET}", file=sys.stderr)
+        return 2
+
+    preflight_brainctl()
+
+    skill_target = workspace / "skills" / "brainctl" / "SKILL.md"
+    agents_target = workspace / "AGENTS.md"
+
+    new_skill = SKILL_TEMPLATE.read_text(encoding="utf-8")
+    existing_skill = read_text(skill_target)
+    skill_changed = new_skill != existing_skill
+
+    snippet_body = AGENTS_SNIPPET.read_text(encoding="utf-8")
+    existing_agents = read_text(agents_target)
+    new_agents = merge(existing_agents, snippet_body)
+    agents_changed = new_agents != existing_agents
+
+    if dry:
+        print(f"[brainctl] --dry: workspace = {workspace}")
+        if skill_changed:
+            print(f"[brainctl] --dry: would write {skill_target}")
+        else:
+            print(f"[brainctl] --dry: {skill_target} already up to date.")
+        if agents_changed:
+            print(f"[brainctl] --dry: would rewrite {agents_target}:")
+            print("---")
+            sys.stdout.write(new_agents)
+            print("---")
+        else:
+            print(f"[brainctl] --dry: {agents_target} already up to date.")
+        return 0
+
+    if skill_changed:
+        skill_target.parent.mkdir(parents=True, exist_ok=True)
+        skill_target.write_text(new_skill, encoding="utf-8")
+        print(f"[brainctl] installed skill file: {skill_target}")
+    else:
+        print(f"[brainctl] skill file: {skill_target} (already up to date)")
+
+    if agents_changed:
+        agents_target.parent.mkdir(parents=True, exist_ok=True)
+        bak = backup(agents_target)
+        agents_target.write_text(new_agents, encoding="utf-8")
+        print(f"[brainctl] merged brainctl block into {agents_target}"
+              + (f" (backup: {bak})" if bak else ""))
+    else:
+        print(f"[brainctl] {agents_target} already up to date.")
+
+    return 0
+
+
+def uninstall(workspace: Path, dry: bool) -> int:
+    skill_target = workspace / "skills" / "brainctl" / "SKILL.md"
+    agents_target = workspace / "AGENTS.md"
+
+    existing_agents = read_text(agents_target)
+    has_block = SENTINEL_START in existing_agents
+    has_skill = skill_target.exists()
+
+    if not has_block and not has_skill:
+        print(f"[brainctl] nothing to remove under {workspace}.")
+        return 0
+
+    if dry:
+        if has_skill:
+            print(f"[brainctl] --dry: would remove {skill_target}")
+        if has_block:
+            print(f"[brainctl] --dry: would strip brainctl block from {agents_target}")
+        return 0
+
+    if has_skill:
+        skill_target.unlink()
+        # Remove the now-empty skills/brainctl dir if possible.
+        try:
+            skill_target.parent.rmdir()
+        except OSError:
+            pass
+        print(f"[brainctl] removed {skill_target}")
+
+    if has_block:
+        new_text = strip_block(existing_agents).rstrip() + "\n"
+        bak = backup(agents_target)
+        agents_target.write_text(new_text, encoding="utf-8")
+        print(f"[brainctl] stripped brainctl block from {agents_target}"
+              + (f" (backup: {bak})" if bak else ""))
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Install brainctl skill + AGENTS.md snippet into an OpenClaw workspace."
+    )
+    parser.add_argument("--dry", action="store_true",
+                        help="Preview changes without writing.")
+    parser.add_argument("--uninstall", action="store_true",
+                        help="Remove the skill file and AGENTS.md brainctl block.")
+    parser.add_argument("--path", dest="path",
+                        help="Workspace override (default: ~/.openclaw/workspace).")
+    args = parser.parse_args()
+
+    workspace = workspace_path(args.path)
+
+    if args.uninstall:
+        return uninstall(workspace, args.dry)
+    return install(workspace, args.dry)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/openclaw/brainctl/plugin.yaml
+++ b/plugins/openclaw/brainctl/plugin.yaml
@@ -1,0 +1,7 @@
+name: brainctl
+version: 0.1.0
+description: "OpenClaw persistent memory via brainctl. Drops a brainctl skill into the OpenClaw workspace and merges an AGENTS.md snippet so Pi reaches for brainctl automatically via the CLI."
+pip_dependencies:
+  - "brainctl>=1.2.0"
+requires_env:
+  - BRAIN_DB   # optional — defaults to ~/agentmemory/db/brain.db

--- a/plugins/rig/brainctl/README.md
+++ b/plugins/rig/brainctl/README.md
@@ -1,0 +1,41 @@
+# brainctl x Rig
+
+> **Status:** Placeholder — not yet implemented. Tracked in
+> [`plugins/TRADING_INTEGRATIONS.md`](../../TRADING_INTEGRATIONS.md#priority-1--crypto-native-agent-frameworks).
+
+## Why this integration matters
+
+[Rig](https://rig.rs) (from 0xPlaygrounds) is the Rust-first LLM
+agent framework picked up fast by high-performance crypto, MEV, and
+arbitrage bots that can't afford Python's GIL or its dependency
+sprawl. It's the only serious agent framework in the Rust ecosystem
+with a real tool-use abstraction.
+
+brainctl has no Rust story today — everything ships Python or TS.
+A first-class Rig integration is the only path to agents built on
+Rig's `Agent` + `Tool` traits.
+
+## Planned integration pattern
+
+**Native Rust crate.** Ship a `brainctl-rig` crate implementing
+Rig's [`Tool`](https://docs.rs/rig-core/latest/rig/tool/trait.Tool.html)
+trait for each of brainctl's primitive ops (`orient`, `memory_add`,
+`decision_add`, `search`, `wrap_up`).
+
+First cut shells out to the `brainctl` CLI via
+`std::process::Command` — simple, robust, mirrors how the
+mixin-pattern plugins work. A future v0.2 could link against a
+pure-Rust SQLite backend for in-process memory once one exists.
+
+## Upstream
+
+- https://github.com/0xPlaygrounds/rig
+- https://rig.rs
+- https://docs.rs/rig-core
+
+## Contributing
+
+PRs welcome. No existing brainctl plugin is in Rust — this will be
+the reference. Match the CLI-shell-out shape used by
+`plugins/freqtrade/brainctl/mixin.py` and document the crate
+publishing flow in its own `README.md`.

--- a/plugins/rig/brainctl/plugin.yaml
+++ b/plugins/rig/brainctl/plugin.yaml
@@ -1,0 +1,6 @@
+name: brainctl
+version: 0.0.0-placeholder
+status: placeholder
+description: "PLACEHOLDER — brainctl integration for Rig, the Rust LLM agent framework from 0xPlaygrounds. Not yet implemented. See plugins/TRADING_INTEGRATIONS.md for the roadmap."
+pip_dependencies: []
+requires_env: []

--- a/plugins/virtuals-game/brainctl/README.md
+++ b/plugins/virtuals-game/brainctl/README.md
@@ -1,0 +1,44 @@
+# brainctl x Virtuals GAME SDK
+
+> **Status:** Placeholder — not yet implemented. Tracked in
+> [`plugins/TRADING_INTEGRATIONS.md`](../../TRADING_INTEGRATIONS.md#priority-1--crypto-native-agent-frameworks).
+
+## Why this integration matters
+
+The [Virtuals Protocol](https://whitepaper.virtuals.io) GAME SDK
+(Generative Agent Model Engine) powers the largest crypto-AI agent
+ecosystem by market cap — Luna, aixbt, and the broader $VIRTUAL
+cohort. Virtuals agents ship with long-running personalities,
+onchain identities, and multi-worker task loops, but they have no
+shared memory substrate: each agent rolls its own state store, or
+goes without.
+
+brainctl is a drop-in fix: a shared, queryable, graph-aware memory
+every GAME agent can read from and write to.
+
+## Planned integration pattern
+
+**Custom worker wrapper + function registry.** GAME's agent runtime
+takes a list of Workers, each exposing Functions. This plugin ships:
+
+- A TypeScript package `@brainctl/game-worker` exporting a
+  `createBrainctlWorker()` factory that returns a GAME-compatible
+  Worker with functions `orient`, `remember`, `recall`, `decide`,
+  and `wrapUp`.
+- A Python mirror for the `game-python` SDK with the same surface.
+
+Under the hood both implementations shell out to `brainctl-mcp` or
+the `brainctl` CLI, so they inherit the full tool surface without
+re-implementing it.
+
+## Upstream
+
+- https://github.com/game-by-virtuals
+- https://whitepaper.virtuals.io
+- https://docs.game.virtuals.io
+
+## Contributing
+
+PRs welcome. Use `plugins/eliza/brainctl/src/` as the TS template
+and match the shape spelled out in
+[`plugins/TRADING_INTEGRATIONS.md`](../../TRADING_INTEGRATIONS.md).

--- a/plugins/virtuals-game/brainctl/plugin.yaml
+++ b/plugins/virtuals-game/brainctl/plugin.yaml
@@ -1,0 +1,6 @@
+name: brainctl
+version: 0.0.0-placeholder
+status: placeholder
+description: "PLACEHOLDER — brainctl integration for Virtuals Protocol GAME SDK. Not yet implemented. See plugins/TRADING_INTEGRATIONS.md for the roadmap."
+pip_dependencies: []
+requires_env: []

--- a/plugins/zerebro/brainctl/README.md
+++ b/plugins/zerebro/brainctl/README.md
@@ -1,0 +1,40 @@
+# brainctl x ZerePy (Zerebro)
+
+> **Status:** Placeholder — not yet implemented. Tracked in
+> [`plugins/TRADING_INTEGRATIONS.md`](../../TRADING_INTEGRATIONS.md#priority-1--crypto-native-agent-frameworks).
+
+## Why this integration matters
+
+[ZerePy](https://github.com/blorm-network/ZerePy) is the reference
+agent framework for the $ZEREBRO cohort — Python/TS-first, onchain,
+and heavily wired into social surfaces (Twitter/X, Discord,
+Farcaster). It's the closest thing to Eliza on the Solana side and
+targets exactly the audience brainctl-launch is courting.
+
+ZerePy agents persist connections (Twitter, RPC, LLM) but lose all
+reasoning context on restart. brainctl plugs the gap with a shared
+memory brain across sessions and agents.
+
+## Planned integration pattern
+
+**Plugin package** — same shape as `plugins/eliza/brainctl/src/`.
+Registers brainctl as a ZerePy connection type with actions:
+
+- `brainctl.orient` — load context on agent start
+- `brainctl.remember` — store a memory
+- `brainctl.decide` — log a decision with rationale
+- `brainctl.search` — retrieve recent memories
+- `brainctl.wrap_up` — emit a session summary on shutdown
+
+Uses the same `Brain` Python API bindings as the Eliza plugin for
+consistency.
+
+## Upstream
+
+- https://github.com/blorm-network/ZerePy
+
+## Contributing
+
+PRs welcome. Use `plugins/eliza/brainctl/` as the template and match
+the shape in
+[`plugins/TRADING_INTEGRATIONS.md`](../../TRADING_INTEGRATIONS.md).

--- a/plugins/zerebro/brainctl/plugin.yaml
+++ b/plugins/zerebro/brainctl/plugin.yaml
@@ -1,0 +1,6 @@
+name: brainctl
+version: 0.0.0-placeholder
+status: placeholder
+description: "PLACEHOLDER — brainctl integration for ZerePy (the Zerebro agent framework). Not yet implemented. See plugins/TRADING_INTEGRATIONS.md for the roadmap."
+pip_dependencies: []
+requires_env: []


### PR DESCRIPTION
## Summary

Widens brainctl plugin coverage for the crypto-launch push.

- **cursor** (full) — MCP installer for `~/.cursor/mcp.json` + `.cursor/rules/brainctl.mdc` template
- **openclaw** (full) — workspace skill injection into `~/.openclaw/workspace/skills/brainctl/` + `AGENTS.md` snippet merge
- **7 placeholders** — crypto-native agent frameworks (coinbase-agentkit, virtuals-game, rig, zerebro) + pro-grade trading bots (hummingbot, nautilustrader, octobot), each with `plugin.yaml` (`status: placeholder`) and a README describing the planned integration pattern
- **`plugins/TRADING_INTEGRATIONS.md`** — roadmap doc covering current coverage, the three reusable integration patterns, priority tiers, and deliberately-skipped targets (including Devin, which has no local install surface)

24 files added under `plugins/`, zero changes outside `plugins/`. No core brainctl, CLI, or MCP changes.

Devin was descoped: cloud-only, no MCP / hook / skill surface to install into.

## Test plan

- [ ] `python3 plugins/cursor/brainctl/install.py --dry` prints a valid JSON preview with no writes
- [ ] `python3 plugins/cursor/brainctl/install.py --print` emits the sentinel-wrapped entry
- [ ] `python3 plugins/openclaw/brainctl/install.py --dry --path /tmp/fake-openclaw` logs two "would ..." lines
- [ ] Installer idempotency: real install into throwaway path twice, second run reports "already up to date"
- [ ] Uninstall round-trip: install → uninstall leaves target files byte-identical to pre-install state
- [ ] Placeholder dirs each contain `plugin.yaml` + `README.md` (7 dirs)
- [ ] `plugins/TRADING_INTEGRATIONS.md` internal links resolve