### PR TITLE
release: v2.4.9 — audit follow-up (retrieval, scoring parity, MCP hygiene)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,85 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.4.9] — 2026-04-20 — *Audit follow-up: retrieval correctness, scoring parity, MCP hygiene*
+
+Second slice of the 2026-04-19 audit fix wave. Ships the remaining HIGHs
+plus six MEDIUMs covering scoring parity, retrieval-pipeline dead code,
+federation input safety, and MCP-layer hygiene.
+
+### Fixed — scoring parity
+
+- **`_surprise_score_mcp` was a stale duplicate** that missed the 2.2.3
+  neutral-fallback fix; the MCP write path — the dominant one in
+  practice — still returned `(1.0, "fts5_no_matches")` where
+  `_impl._surprise_score` returned `(0.5, "fts5_no_matches_neutral")`.
+  Deleted the copy and imported the canonical scorer. Regression test
+  at `tests/test_mcp_surprise_score_parity.py` locks the parity.
+- **`affect_log.safety_flag` was NULL on every row** because
+  `brain.affect_log` read the wrong key from the classifier
+  (`safety_flag` singular) when `classify_affect` returns
+  `safety_flags` (plural list of pattern dicts). Now serializes the
+  list as JSON when any pattern fires; NULL otherwise — keeps the
+  `idx_affect_safety` sparse index honest.
+
+### Fixed — retrieval correctness
+
+- **The FTS-confidence relative-anchor gate was dead code.** Entry
+  condition already established the relative-strong verdict, but the
+  block immediately reassigned `rel_strong` to the opposite relation.
+  Only absolute-threshold detection was running.
+- **`graph_traversal` intent produced zero-row expansion on `events`**
+  because the caller did `tbl_key.rstrip("s")` before passing to
+  `_graph_expand`, which queries `knowledge_edges` with plural table
+  names. Now passes the canonical name directly.
+- **Events/context silently cascaded into FTS-only** when the memories
+  bucket tripped the `_fts_strong_anchor` gate. Added matching
+  `_debug_skips` entries so operators can see the cascade.
+- **`_reason_l1_search`, `cmd_push`, and `Brain.orient()`** now build
+  the same `_build_fts_match_expression(sanitize(...))` OR expression
+  `cmd_search` uses, instead of bare sanitize. Multi-word queries no
+  longer fall into FTS5 implicit-AND semantics at those callsites.
+
+### Fixed — CLI / diagnostics
+
+- **`brainctl doctor` hardcoded `"ok": True` and exited 0 regardless
+  of health.** JSON output now reflects the actual verdict
+  (`ok == healthy`), and the process exits 1 when any issue is
+  present — shell `$?`-based automation now works correctly.
+- **Plugin env-var mismatch between `BRAINCTL_DB` and `BRAIN_DB`.**
+  `paths.get_db_path()` now honors `BRAINCTL_DB` as the go-forward
+  canonical name (matches the `BRAINCTL_HOME` / `_BLOBS_DIR` /
+  `_BACKUPS_DIR` family) while keeping `BRAIN_DB` working as a
+  deprecated alias. `BRAINCTL_DB` wins when both are set.
+
+### Fixed — federation / merge / MCP shape
+
+- **Federation LIKE fallbacks didn't escape `%` / `_`** in the four
+  LIKE query sites across `federated_memory_search`,
+  `federated_entity_search`, and `federated_search`. Introduced
+  `_escape_like` + `ESCAPE '\\'` on every LIKE clause so `api_key`
+  matches literally, not `apikey` or `api-key`.
+- **Self-merge surfaced as `"database is locked"`.** Added an
+  explicit `source == target` guard (resolved to absolute path) that
+  raises a clear `ValueError` before `ATTACH DATABASE` runs.
+- **MCP error shape normalized** across `mcp_server` and
+  `mcp_tools_knowledge`: every error return now carries
+  `{"ok": False, "error": ...}` instead of a bare `{"error": ...}`.
+  Clients that branch on `ok` no longer need per-tool special-cases.
+
+### Fixed — packaging
+
+- **Three MCP tools depended on `~/bin/lib/` drop-ins**
+  (`belief_revision`, `outcome_eval`, `quantum_retrieval`) — they were
+  unreachable on PyPI installs. Moved all three in-tree under
+  `agentmemory.lib.*`; imports prefer the in-tree copy and fall back
+  to the legacy path for users on the old layout.
+
+### Testing
+
+`1866 passed, 28 skipped, 2 xfailed` locally (3 new tests vs 2.4.8
+for the surprise-score parity regression).
+
 ## [2.4.8] — 2026-04-20 — *Audit hotfix: fresh-install migrate + MCP dispatch*
 
 Closes the two CRITICAL findings from the 2026-04-19 audit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "brainctl"
-version = "2.4.8"
+version = "2.4.9"
 description = "Context engineering for AI agents — persistent memory, knowledge graph, affect tracking, and MCP server. Single SQLite file, zero LLM cost."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/agentmemory/__init__.py
+++ b/src/agentmemory/__init__.py
@@ -9,7 +9,7 @@ Quick start:
     brain.search("preferences")
 """
 
-__version__ = "2.4.8"
+__version__ = "2.4.9"
 
 from agentmemory.brain import Brain
 

--- a/src/agentmemory/_impl.py
+++ b/src/agentmemory/_impl.py
@@ -6815,12 +6815,19 @@ def cmd_search(args, *, db=None, db_path: Optional[str] = None):
                 if len(fts_list) >= 3:
                     try:
                         third_score = float(fts_list[2].get("fts_rank") or 0.0)
+                        # Entry condition means top is ≥ 1.5× the BM25
+                        # strength of third (ranks are negative in SQLite
+                        # FTS5; more negative = stronger). Passing the
+                        # filter IS the relative-strong verdict. Before
+                        # 2.4.9, a second comparison inside the block
+                        # reassigned rel_strong to the OPPOSITE relation
+                        # (`top_score * 0.67 > third_score`) which is
+                        # always False in the space the entry filter just
+                        # carved out — the whole relative-anchor gate was
+                        # dead. See docs/audit_2026_04_19/02_retrieval.md
+                        # F-01.
                         if top_score < -0.2 and third_score > top_score * 0.67:
-                            # top_score more negative than third * 1.5 means
-                            # top is ≥ 1.5× the BM25 strength of third.
-                            # Equivalently: third < top * (2/3) when both
-                            # are negative.
-                            rel_strong = top_score * 0.67 > third_score
+                            rel_strong = True
                     except (TypeError, ValueError):
                         pass
                 _fts_strong_anchor = abs_strong or rel_strong
@@ -6882,7 +6889,12 @@ def cmd_search(args, *, db=None, db_path: Optional[str] = None):
         if hybrid:
             merged = _rrf_fuse(fts_list, vec_list)
         else:
+            # Before 2.4.9, when the memories bucket tripped the
+            # `_fts_strong_anchor` gate and flipped `hybrid = False`,
+            # events and context silently fell back to FTS-only without
+            # a debug marker — operators couldn't see the cascade.
             merged = [r | {"rrf_score": 0.0, "source": "keyword"} for r in fts_list]
+            _debug_skips.setdefault("events.vec_skipped", "fts_strong_anchor_cascade_from_memories")
         trimmed = _apply_recency_and_trim(
             merged,
             lambda r: ("project:" + r["project"]) if r.get("project") else "global",
@@ -6900,7 +6912,9 @@ def cmd_search(args, *, db=None, db_path: Optional[str] = None):
         if hybrid:
             merged = _rrf_fuse(fts_list, vec_list)
         else:
+            # See the matching note in the events block above.
             merged = [r | {"rrf_score": 0.0, "source": "keyword"} for r in fts_list]
+            _debug_skips.setdefault("context.vec_skipped", "fts_strong_anchor_cascade_from_memories")
         trimmed = _apply_recency_and_trim(
             merged,
             lambda r: ("project:" + r["project"]) if r.get("project") else "global",
@@ -7004,7 +7018,14 @@ def cmd_search(args, *, db=None, db_path: Optional[str] = None):
                 top_items = results.get(tbl_key, [])[:3]
                 if top_items:
                     already = {r["id"] for r in results.get(tbl_key, [])}
-                    extra = _graph_expand(db, top_items, tbl_key.rstrip("s") if tbl_key != "memories" else "memories", already)
+                    # _graph_expand queries knowledge_edges where
+                    # source_table / target_table are the plural canonical
+                    # names ('memories', 'events', 'context'). Before 2.4.9
+                    # this used `tbl_key.rstrip("s")` which yielded "event"
+                    # for "events" (edge rows store "events") — matching
+                    # zero rows and silently disabling graph expansion on
+                    # the events bucket. Pass `tbl_key` directly.
+                    extra = _graph_expand(db, top_items, tbl_key, already)
                     results.get(tbl_key, []).extend(extra)
 
     if db_vec:
@@ -9105,6 +9126,7 @@ def cmd_doctor(args):
             ))
 
     # Verdict
+    healthy = len(issues) == 0
     if not getattr(args, "json", False):
         if issues:
             print(fail(f"\n  {len(issues)} issue(s) found:"))
@@ -9114,9 +9136,15 @@ def cmd_doctor(args):
             print(ok("\n  All checks passed."))
 
     if getattr(args, "json", False):
+        # Before 2.4.9, "ok" was hardcoded True regardless of how many
+        # issues we found — a caller piping `brainctl doctor --json` into
+        # an automation that branched on `.ok` always saw success. Tie
+        # "ok" to the actual verdict and exit non-zero on problems so
+        # shell-level `$?` checks behave the way a "doctor" command is
+        # expected to. "healthy" is kept as an alias for back-compat.
         json_out({
-            "ok": True,
-            "healthy": len(issues) == 0,
+            "ok": healthy,
+            "healthy": healthy,
             "issues": issues,
             "db_path": str(DB_PATH),
             "db_size_mb": db_size,
@@ -9125,6 +9153,10 @@ def cmd_doctor(args):
             "wallet": wallet_status,
             "solana_rpc": rpc_status,
         })
+
+    # Non-zero exit when issues are present regardless of output mode.
+    if not healthy:
+        sys.exit(1)
 
 
 def cmd_profile_list(args):
@@ -13616,7 +13648,10 @@ def cmd_push(args):
     push_id = _uuid_mod.uuid4().hex[:12]
     # More aggressive sanitize for push: strip colons, commas, plus signs that confuse FTS5
     _raw_fts = _sanitize_fts_query(task_desc)
-    fts_query = re.sub(r'[,:+<>]', ' ', _raw_fts).strip()
+    _raw_fts = re.sub(r'[,:+<>]', ' ', _raw_fts).strip()
+    # Apply the same OR-expression expansion cmd_search uses so multi-word
+    # task descriptions aren't interpreted as implicit-AND (audit I14).
+    fts_query = _build_fts_match_expression(_raw_fts)
 
     # ---- score memories via hybrid RRF (same pipeline as cmd_search) ----
     db_vec = _try_get_db_with_vec()
@@ -15414,7 +15449,11 @@ def cmd_whosknows(args):
 
 def _reason_l1_search(db, query: str, limit: int = 10):
     """L1 associative retrieval — hybrid BM25+vec RRF over memories and events."""
-    fts_query = _sanitize_fts_query(query)
+    # Mirror cmd_search: build an OR expression over meaningful tokens so
+    # multi-word natural-language queries don't fall back to FTS5's
+    # implicit-AND (which would demand every token appear in the same row).
+    # Before 2.4.9 this callsite only sanitized — audit I14.
+    fts_query = _build_fts_match_expression(_sanitize_fts_query(query))
     db_vec = _try_get_db_with_vec()
     q_blob = _embed_query_safe(query) if db_vec else None
     hybrid = db_vec is not None and q_blob is not None

--- a/src/agentmemory/brain.py
+++ b/src/agentmemory/brain.py
@@ -632,7 +632,19 @@ class Brain:
             search_q = query or project
             if search_q:
                 try:
-                    fts_q = _safe_fts(search_q)
+                    # Use the same canonical expression cmd_search does
+                    # (sanitize → stopword-filter → OR join) so orient
+                    # and search agree on candidate set for the same
+                    # query string. Audit I15 — previously used the
+                    # legacy `_safe_fts()` which kept stopwords and
+                    # joined every token with OR.
+                    from agentmemory._impl import (
+                        _sanitize_fts_query,
+                        _build_fts_match_expression,
+                    )
+                    fts_q = _build_fts_match_expression(
+                        _sanitize_fts_query(search_q)
+                    )
                     if fts_q:
                         mrows = db.execute(
                             "SELECT m.id, m.content, m.category, m.confidence, m.created_at "
@@ -976,7 +988,20 @@ class Brain:
                     result.get("affect_label"),
                     result.get("cluster"),
                     result.get("functional_state"),
-                    result.get("safety_flag"),
+                    # classify_affect returns `safety_flags` (plural list of
+                    # {pattern, severity, description} dicts). Before 2.4.9
+                    # this read `safety_flag` (singular) and silently got
+                    # None every row — affect_log.safety_flag has been NULL
+                    # for every write since the column shipped, and the
+                    # idx_affect_safety sparse index never had anything to
+                    # point at. Serialize the list as JSON so the column
+                    # preserves all pattern matches when any fire; NULL
+                    # when none do, to keep the sparse index honest.
+                    (
+                        json.dumps(result["safety_flags"])
+                        if result.get("safety_flags")
+                        else None
+                    ),
                     text,
                     source,
                     now,

--- a/src/agentmemory/federation.py
+++ b/src/agentmemory/federation.py
@@ -27,6 +27,20 @@ def _sanitize_fts_query(query: str) -> str:
     return re.sub(r"\s+", " ", cleaned).strip()
 
 
+def _escape_like(term: str) -> str:
+    """Escape SQLite LIKE wildcard metacharacters.
+
+    LIKE treats ``%`` and ``_`` as metacharacters, and any literal ``\\``
+    has to be escaped before them. Before 2.4.9 the federated LIKE
+    fallbacks fed user input straight into the pattern, so a query like
+    ``api_key`` matched ``apikey`` / ``api-key`` / anything with the
+    same prefix as the bare `_` matched any single char. Audit I16.
+
+    Paired with ``ESCAPE '\\'`` on the LIKE clause.
+    """
+    return (term or "").replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 def _open_ro(path: str) -> sqlite3.Connection | None:
     """Open a SQLite DB read-only. Returns None on error."""
     try:
@@ -183,19 +197,20 @@ def federated_memory_search(
                 except sqlite3.OperationalError as exc:
                     logger.warning("federation: FTS error in %s: %s", path, exc)
             elif _has_table(conn, "memories"):
-                # Fallback: LIKE search
-                pattern = f"%{query}%"
+                # Fallback: LIKE search (see _escape_like docstring for the
+                # wildcard-escaping rationale)
+                pattern = f"%{_escape_like(query)}%"
                 if category:
                     rows = conn.execute(
                         "SELECT id, content, category, confidence, created_at, agent_id "
-                        "FROM memories WHERE content LIKE ? AND category = ? "
+                        "FROM memories WHERE content LIKE ? ESCAPE '\\' AND category = ? "
                         "AND retired_at IS NULL ORDER BY created_at DESC LIMIT ?",
                         (pattern, category, limit),
                     ).fetchall()
                 else:
                     rows = conn.execute(
                         "SELECT id, content, category, confidence, created_at, agent_id "
-                        "FROM memories WHERE content LIKE ? "
+                        "FROM memories WHERE content LIKE ? ESCAPE '\\' "
                         "AND retired_at IS NULL ORDER BY created_at DESC LIMIT ?",
                         (pattern, limit),
                     ).fetchall()
@@ -244,18 +259,18 @@ def federated_entity_search(
         try:
             if not _has_table(conn, "entities"):
                 continue
-            pattern = f"%{name}%"
+            pattern = f"%{_escape_like(name)}%"
             if entity_type:
                 rows = conn.execute(
                     "SELECT id, name, entity_type, observations, created_at, agent_id "
-                    "FROM entities WHERE name LIKE ? AND entity_type = ? "
+                    "FROM entities WHERE name LIKE ? ESCAPE '\\' AND entity_type = ? "
                     "AND retired_at IS NULL ORDER BY created_at DESC",
                     (pattern, entity_type),
                 ).fetchall()
             else:
                 rows = conn.execute(
                     "SELECT id, name, entity_type, observations, created_at, agent_id "
-                    "FROM entities WHERE name LIKE ? "
+                    "FROM entities WHERE name LIKE ? ESCAPE '\\' "
                     "AND retired_at IS NULL ORDER BY created_at DESC",
                     (pattern,),
                 ).fetchall()
@@ -332,7 +347,7 @@ def federated_search(
                             q_args,
                         ).fetchall()
                     else:
-                        pattern = f"%{query}%"
+                        pattern = f"%{_escape_like(query)}%"
                         q_args = [pattern]
                         agent_clause = " AND agent_id = ?" if agent_id else ""
                         if agent_id:
@@ -340,7 +355,7 @@ def federated_search(
                         q_args.append(limit)
                         rows = conn.execute(
                             f"SELECT id, content, category, confidence, created_at, agent_id "
-                            f"FROM memories WHERE content LIKE ?{agent_clause} "
+                            f"FROM memories WHERE content LIKE ? ESCAPE '\\'{agent_clause} "
                             f"AND retired_at IS NULL ORDER BY created_at DESC LIMIT ?",
                             q_args,
                         ).fetchall()
@@ -370,7 +385,7 @@ def federated_search(
                             q_args,
                         ).fetchall()
                     else:
-                        pattern = f"%{query}%"
+                        pattern = f"%{_escape_like(query)}%"
                         q_args = [pattern]
                         agent_clause = " AND agent_id = ?" if agent_id else ""
                         if agent_id:
@@ -379,7 +394,7 @@ def federated_search(
                         rows = conn.execute(
                             f"SELECT id, summary, event_type, project, importance, "
                             f"created_at, agent_id FROM events "
-                            f"WHERE summary LIKE ?{agent_clause} "
+                            f"WHERE summary LIKE ? ESCAPE '\\'{agent_clause} "
                             f"ORDER BY created_at DESC LIMIT ?",
                             q_args,
                         ).fetchall()
@@ -391,7 +406,7 @@ def federated_search(
             # --- entities ---
             if "entities" in tables and _has_table(conn, "entities"):
                 try:
-                    pattern = f"%{query}%"
+                    pattern = f"%{_escape_like(query)}%"
                     q_args = [pattern, pattern]
                     agent_clause = " AND agent_id = ?" if agent_id else ""
                     if agent_id:
@@ -400,7 +415,7 @@ def federated_search(
                     rows = conn.execute(
                         f"SELECT id, name, entity_type, observations, created_at, agent_id "
                         f"FROM entities "
-                        f"WHERE (name LIKE ? OR observations LIKE ?){agent_clause} "
+                        f"WHERE (name LIKE ? ESCAPE '\\' OR observations LIKE ? ESCAPE '\\'){agent_clause} "
                         f"AND retired_at IS NULL "
                         f"ORDER BY created_at DESC LIMIT ?",
                         q_args,

--- a/src/agentmemory/lib/belief_revision.py
+++ b/src/agentmemory/lib/belief_revision.py
@@ -1,0 +1,377 @@
+"""
+belief_revision.py — AGM Credibility-Weighted Conflict Resolution (COS-406)
+
+Implements `resolve-conflict` logic for brainctl:
+  - Credibility scoring via Bayesian mean × recency × trust × expertise
+  - Winner/loser selection with threshold and escalation guards
+  - Retraction of loser + supersedes edge insertion
+  - Permanent / too-close escalation to Hermes
+"""
+
+import math
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+DB_PATH = Path.home() / "agentmemory" / "db" / "brain.db"
+
+
+def _get_db(db_path: str | None = None) -> sqlite3.Connection:
+    path = db_path or str(DB_PATH)
+    conn = sqlite3.connect(path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Credibility score
+# ---------------------------------------------------------------------------
+
+def compute_credibility(memory: dict, agent_expertise: dict) -> float:
+    """
+    C(m) = bayesian_mean(alpha, beta)
+           * (1 + log1p(recalled_count) / 10)
+           * max(0, 1 - days_since_write / 365)
+           * trust_score
+           * agent_expertise_score
+
+    memory keys: alpha, beta, recalled_count, created_at, trust_score
+    agent_expertise: mapping of domain -> strength (0-1), used as mean expertise weight
+    """
+    alpha = float(memory.get("alpha") or 1.0)
+    beta  = float(memory.get("beta")  or 1.0)
+    bayesian_mean = alpha / (alpha + beta)
+
+    recalled = int(memory.get("recalled_count") or 0)
+    recall_boost = 1.0 + math.log1p(recalled) / 10.0
+
+    created_at = memory.get("created_at") or memory.get("updated_at") or ""
+    try:
+        created_dt = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        if created_dt.tzinfo is None:
+            created_dt = created_dt.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        days_since = max(0.0, (now - created_dt).total_seconds() / 86400.0)
+    except (ValueError, AttributeError):
+        days_since = 0.0
+    recency = max(0.0, 1.0 - days_since / 365.0)
+
+    trust = float(memory.get("trust_score") or 1.0)
+
+    # Mean expertise across all domains if available, else 1.0
+    if agent_expertise:
+        expertise_score = sum(agent_expertise.values()) / len(agent_expertise)
+    else:
+        expertise_score = 1.0
+
+    return bayesian_mean * recall_boost * recency * trust * expertise_score
+
+
+def _fetch_expertise(conn: sqlite3.Connection, agent_id: str) -> dict:
+    rows = conn.execute(
+        "SELECT domain, strength FROM agent_expertise WHERE agent_id = ?",
+        (agent_id,)
+    ).fetchall()
+    return {r["domain"]: float(r["strength"]) for r in rows}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def list_conflicts(db_path: str | None = None) -> list[dict]:
+    """Return all open belief_conflicts with credibility scores for both sides."""
+    conn = _get_db(db_path)
+    rows = conn.execute(
+        """
+        SELECT bc.id, bc.topic, bc.conflict_type, bc.severity,
+               bc.agent_a_id, bc.agent_b_id, bc.belief_a, bc.belief_b,
+               bc.detected_at, bc.requires_hermes_intervention
+        FROM belief_conflicts bc
+        WHERE bc.resolved_at IS NULL
+        ORDER BY bc.severity DESC, bc.detected_at ASC
+        """
+    ).fetchall()
+
+    result = []
+    for r in rows:
+        entry = dict(r)
+        # Attach expertise-weighted scores where we have linked memory IDs
+        # (belief_a/belief_b are free text here, not memory IDs in this schema)
+        entry["score_a"] = None
+        entry["score_b"] = None
+        result.append(entry)
+    conn.close()
+    return result
+
+
+def resolve_conflict(
+    conflict_id: int,
+    db_path: str | None = None,
+    dry_run: bool = False,
+    force_winner_id: str | None = None,
+    threshold: float = 0.05,
+) -> dict:
+    """
+    Apply AGM credibility-weighted resolution to a single open conflict.
+
+    Returns a dict with keys:
+      winner_id, loser_id, score_a, score_b, score_delta, action,
+      escalated, escalation_reason, dry_run
+    """
+    conn = _get_db(db_path)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+
+    # 1. Load conflict
+    row = conn.execute(
+        """
+        SELECT id, topic, conflict_type, severity,
+               agent_a_id, agent_b_id, belief_a, belief_b,
+               requires_hermes_intervention
+        FROM belief_conflicts
+        WHERE id = ? AND resolved_at IS NULL
+        """,
+        (conflict_id,)
+    ).fetchone()
+
+    if not row:
+        conn.close()
+        return {"error": f"Conflict #{conflict_id} not found or already resolved."}
+
+    conflict = dict(row)
+
+    # 2. Find the most recent non-retracted memories linked to each agent's position
+    #    The conflict stores free-text beliefs; find memories matching agent_a_id/agent_b_id
+    #    with content overlapping the topic/belief.
+    def _best_memory(agent_id: str, belief_text: str) -> dict | None:
+        # Try exact content match first, then fall back to most-confident active memory
+        candidates = conn.execute(
+            """
+            SELECT id, alpha, beta, recalled_count, created_at, trust_score,
+                   temporal_class, confidence, content
+            FROM memories
+            WHERE agent_id = ?
+              AND retracted_at IS NULL
+              AND retired_at IS NULL
+            ORDER BY confidence DESC, recalled_count DESC
+            LIMIT 5
+            """,
+            (agent_id,)
+        ).fetchall()
+        if not candidates:
+            return None
+        # Prefer one whose content overlaps with belief_text
+        belief_words = set(belief_text.lower().split())
+        best = None
+        best_overlap = -1
+        for c in candidates:
+            overlap = len(set(c["content"].lower().split()) & belief_words)
+            if overlap > best_overlap:
+                best_overlap = overlap
+                best = dict(c)
+        return best or dict(candidates[0])
+
+    mem_a = _best_memory(conflict["agent_a_id"], conflict["belief_a"])
+    mem_b = _best_memory(conflict["agent_b_id"] or "unknown", conflict["belief_b"]) if conflict["agent_b_id"] else None
+
+    exp_a = _fetch_expertise(conn, conflict["agent_a_id"])
+    exp_b = _fetch_expertise(conn, conflict["agent_b_id"]) if conflict["agent_b_id"] else {}
+
+    # 3. Compute credibility scores
+    if mem_a:
+        score_a = compute_credibility(mem_a, exp_a)
+    else:
+        # No memory found — use raw confidence placeholder
+        score_a = 0.5
+
+    if mem_b:
+        score_b = compute_credibility(mem_b, exp_b)
+    else:
+        score_b = 0.5 if conflict["agent_b_id"] else 0.3  # ground-truth conflicts default lower
+
+    # 4. Permanent memory guard
+    perm_a = mem_a and mem_a.get("temporal_class") == "permanent"
+    perm_b = mem_b and mem_b.get("temporal_class") == "permanent"
+    if perm_a or perm_b:
+        resolution_result = {
+            "conflict_id": conflict_id,
+            "topic": conflict["topic"],
+            "score_a": score_a,
+            "score_b": score_b,
+            "score_delta": abs(score_a - score_b),
+            "winner_id": None,
+            "loser_id": None,
+            "action": "escalate",
+            "escalated": True,
+            "escalation_reason": "permanent memory involved — requires Hermes review",
+            "dry_run": dry_run,
+        }
+        if not dry_run:
+            conn.execute(
+                "UPDATE belief_conflicts SET requires_hermes_intervention=1 WHERE id=?",
+                (conflict_id,)
+            )
+            conn.commit()
+        conn.close()
+        return resolution_result
+
+    # 5. Threshold guard (too close to call)
+    delta = abs(score_a - score_b)
+    if not force_winner_id and delta < threshold:
+        resolution_result = {
+            "conflict_id": conflict_id,
+            "topic": conflict["topic"],
+            "score_a": score_a,
+            "score_b": score_b,
+            "score_delta": delta,
+            "winner_id": None,
+            "loser_id": None,
+            "action": "escalate",
+            "escalated": True,
+            "escalation_reason": f"scores too close (delta={delta:.4f} < threshold={threshold})",
+            "dry_run": dry_run,
+        }
+        if not dry_run:
+            conn.execute(
+                "UPDATE belief_conflicts SET requires_hermes_intervention=1 WHERE id=?",
+                (conflict_id,)
+            )
+            conn.commit()
+        conn.close()
+        return resolution_result
+
+    # 6. Determine winner
+    if force_winner_id:
+        if force_winner_id == conflict["agent_a_id"] and mem_a:
+            winner_mem = mem_a
+            loser_mem = mem_b
+            winner_agent = conflict["agent_a_id"]
+            loser_agent = conflict["agent_b_id"]
+            w_score, l_score = score_a, score_b
+        elif force_winner_id == conflict["agent_b_id"] and mem_b:
+            winner_mem = mem_b
+            loser_mem = mem_a
+            winner_agent = conflict["agent_b_id"]
+            loser_agent = conflict["agent_a_id"]
+            w_score, l_score = score_b, score_a
+        else:
+            conn.close()
+            return {"error": f"force_winner_id '{force_winner_id}' not matched to conflict agents."}
+    else:
+        if score_a >= score_b:
+            winner_mem = mem_a
+            loser_mem = mem_b
+            winner_agent = conflict["agent_a_id"]
+            loser_agent = conflict["agent_b_id"]
+            w_score, l_score = score_a, score_b
+        else:
+            winner_mem = mem_b
+            loser_mem = mem_a
+            winner_agent = conflict["agent_b_id"]
+            loser_agent = conflict["agent_a_id"]
+            w_score, l_score = score_b, score_a
+
+    winner_mem_id = winner_mem["id"] if winner_mem else None
+    loser_mem_id  = loser_mem["id"]  if loser_mem  else None
+
+    resolution_text = (
+        f"AGM resolved: agent {winner_agent} wins (score={w_score:.4f}) "
+        f"over agent {loser_agent} (score={l_score:.4f}); delta={delta:.4f}"
+    )
+
+    if dry_run:
+        conn.close()
+        return {
+            "conflict_id": conflict_id,
+            "topic": conflict["topic"],
+            "score_a": score_a,
+            "score_b": score_b,
+            "score_delta": delta,
+            "winner_agent": winner_agent,
+            "loser_agent": loser_agent,
+            "winner_mem_id": winner_mem_id,
+            "loser_mem_id": loser_mem_id,
+            "action": "retract_loser",
+            "escalated": False,
+            "escalation_reason": None,
+            "resolution": resolution_text,
+            "dry_run": True,
+        }
+
+    # 7. Retract loser memory
+    if loser_mem_id:
+        conn.execute(
+            """
+            UPDATE memories SET retracted_at=?, retraction_reason=?
+            WHERE id=? AND retracted_at IS NULL
+            """,
+            (now, f"AGM conflict #{conflict_id}: superseded by memory {winner_mem_id}", loser_mem_id)
+        )
+
+    # 8. Insert supersedes edge
+    if winner_mem_id and loser_mem_id:
+        # Check for existing knowledge_edges schema
+        edge_schema = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='knowledge_edges'"
+        ).fetchone()
+        if edge_schema:
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO knowledge_edges
+                  (source_table, source_id, target_table, target_id, relation_type, created_at)
+                VALUES ('memories', ?, 'memories', ?, 'supersedes', ?)
+                """,
+                (winner_mem_id, loser_mem_id, now)
+            )
+
+    # 9. Mark conflict resolved
+    conn.execute(
+        "UPDATE belief_conflicts SET resolved_at=?, resolution=? WHERE id=?",
+        (now, resolution_text, conflict_id)
+    )
+
+    conn.commit()
+    conn.close()
+
+    return {
+        "conflict_id": conflict_id,
+        "topic": conflict["topic"],
+        "score_a": score_a,
+        "score_b": score_b,
+        "score_delta": delta,
+        "winner_agent": winner_agent,
+        "loser_agent": loser_agent,
+        "winner_mem_id": winner_mem_id,
+        "loser_mem_id": loser_mem_id,
+        "action": "retract_loser",
+        "escalated": False,
+        "escalation_reason": None,
+        "resolution": resolution_text,
+        "dry_run": False,
+    }
+
+
+def auto_resolve(
+    db_path: str | None = None,
+    threshold: float = 0.05,
+    dry_run: bool = False,
+) -> list[dict]:
+    """Batch resolve all auto-resolvable open conflicts. Returns list of resolution results."""
+    conn = _get_db(db_path)
+    rows = conn.execute(
+        "SELECT id FROM belief_conflicts WHERE resolved_at IS NULL ORDER BY severity DESC"
+    ).fetchall()
+    conn.close()
+
+    results = []
+    for row in rows:
+        r = resolve_conflict(
+            conflict_id=row["id"],
+            db_path=db_path,
+            dry_run=dry_run,
+            threshold=threshold,
+        )
+        results.append(r)
+    return results

--- a/src/agentmemory/lib/outcome_eval.py
+++ b/src/agentmemory/lib/outcome_eval.py
@@ -1,0 +1,321 @@
+"""
+outcome_eval.py — COS-405: Outcome-Linked Memory Evaluation
+
+Functions for annotating access_log with task outcome signals and computing
+Brier score calibration metrics. Used by brainctl and brainctl-mcp.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Optional
+
+DB_PATH = Path.home() / "agentmemory" / "db" / "brain.db"
+
+VALID_OUTCOMES = {"success", "blocked", "escalated", "cancelled"}
+
+
+def _get_db(db_path: str = None) -> sqlite3.Connection:
+    path = db_path or str(DB_PATH)
+    conn = sqlite3.connect(path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def annotate_task_retrieval(
+    task_id: str,
+    agent_id: str,
+    outcome: str,
+    db_path: str = None,
+) -> int:
+    """
+    Annotate all access_log rows for this agent/task with the task outcome.
+
+    Matches rows where task_id IS NULL and agent_id matches, within a
+    reasonable window (last 24h) — since we don't have the task start time,
+    we annotate the most recent untagged batch.
+
+    Returns the number of rows annotated.
+    """
+    if outcome not in VALID_OUTCOMES:
+        raise ValueError(f"Invalid outcome '{outcome}'. Must be one of: {sorted(VALID_OUTCOMES)}")
+
+    conn = _get_db(db_path)
+    try:
+        # Look up the most recent pre-task uncertainty for this agent
+        unc_row = conn.execute(
+            """
+            SELECT free_energy FROM agent_uncertainty_log
+            WHERE agent_id = ? AND created_at >= datetime('now', '-24 hours')
+            ORDER BY created_at DESC LIMIT 1
+            """,
+            (agent_id,),
+        ).fetchone()
+        pre_uncertainty = unc_row["free_energy"] if unc_row else None
+
+        # Annotate rows: only untagged rows for this agent from the last 24h
+        cursor = conn.execute(
+            """
+            UPDATE access_log
+            SET task_id = ?,
+                task_outcome = ?,
+                pre_task_uncertainty = COALESCE(pre_task_uncertainty, ?)
+            WHERE agent_id = ?
+              AND task_id IS NULL
+              AND created_at >= datetime('now', '-24 hours')
+            """,
+            (task_id, outcome, pre_uncertainty, agent_id),
+        )
+        annotated = cursor.rowcount
+        conn.commit()
+        return annotated
+    finally:
+        conn.close()
+
+
+def compute_brier_score(
+    agent_id: str,
+    period_days: int = 30,
+    db_path: str = None,
+) -> Optional[float]:
+    """
+    Brier score: sum((predicted_confidence - actual_success)²) / N
+
+    Uses access_log rows with task_outcome set, joined to memories via
+    target_id to get the confidence at retrieval time. Returns None when
+    there is insufficient data (< 3 annotated retrievals with outcomes).
+    """
+    conn = _get_db(db_path)
+    try:
+        rows = conn.execute(
+            """
+            SELECT
+                al.task_outcome,
+                COALESCE(m.confidence, 0.5) AS confidence
+            FROM access_log al
+            LEFT JOIN memories m ON m.id = al.target_id
+            WHERE al.agent_id = ?
+              AND al.task_outcome IS NOT NULL
+              AND al.target_table = 'memories'
+              AND al.created_at >= datetime('now', ?)
+            """,
+            (agent_id, f"-{period_days} days"),
+        ).fetchall()
+
+        if len(rows) < 3:
+            return None
+
+        total = 0.0
+        for r in rows:
+            actual = 1.0 if r["task_outcome"] == "success" else 0.0
+            diff = r["confidence"] - actual
+            total += diff * diff
+
+        return total / len(rows)
+    finally:
+        conn.close()
+
+
+def compute_memory_lift(
+    period_days: int = 30,
+    db_path: str = None,
+) -> dict:
+    """
+    Compare task success rate when memory was retrieved vs. cold start.
+
+    Returns:
+      {
+        with_memory_success_rate: float | None,
+        without_memory_success_rate: float | None,
+        lift_pp: float | None,   # percentage points
+        tasks_with_memory: int,
+        tasks_without_memory: int,
+      }
+    """
+    conn = _get_db(db_path)
+    try:
+        # Tasks that had at least one memory retrieval
+        with_mem = conn.execute(
+            """
+            SELECT
+                task_id,
+                MAX(CASE WHEN task_outcome = 'success' THEN 1 ELSE 0 END) AS succeeded
+            FROM access_log
+            WHERE task_id IS NOT NULL
+              AND task_outcome IS NOT NULL
+              AND target_table = 'memories'
+              AND created_at >= datetime('now', ?)
+            GROUP BY task_id
+            """,
+            (f"-{period_days} days",),
+        ).fetchall()
+
+        # Tasks that completed but had no memory retrieval rows
+        without_mem = conn.execute(
+            """
+            SELECT
+                task_id,
+                MAX(CASE WHEN task_outcome = 'success' THEN 1 ELSE 0 END) AS succeeded
+            FROM access_log
+            WHERE task_id IS NOT NULL
+              AND task_outcome IS NOT NULL
+              AND created_at >= datetime('now', ?)
+            GROUP BY task_id
+            HAVING SUM(CASE WHEN target_table = 'memories' THEN 1 ELSE 0 END) = 0
+            """,
+            (f"-{period_days} days",),
+        ).fetchall()
+
+        def _success_rate(rows):
+            if not rows:
+                return None
+            return sum(r["succeeded"] for r in rows) / len(rows)
+
+        rate_with = _success_rate(with_mem)
+        rate_without = _success_rate(without_mem)
+        lift = None
+        if rate_with is not None and rate_without is not None:
+            lift = (rate_with - rate_without) * 100.0
+
+        return {
+            "with_memory_success_rate": rate_with,
+            "without_memory_success_rate": rate_without,
+            "lift_pp": lift,
+            "tasks_with_memory": len(with_mem),
+            "tasks_without_memory": len(without_mem),
+        }
+    finally:
+        conn.close()
+
+
+def compute_precision_at_k(
+    agent_id: str,
+    k: int = 5,
+    period_days: int = 30,
+    db_path: str = None,
+) -> Optional[float]:
+    """
+    Precision@k: fraction of the top-k retrieved memories (per task) that
+    came from tasks that succeeded. Uses retrieval_contributed when set,
+    falls back to task_outcome == 'success'.
+    """
+    conn = _get_db(db_path)
+    try:
+        rows = conn.execute(
+            """
+            SELECT
+                task_id,
+                id,
+                task_outcome,
+                retrieval_contributed,
+                ROW_NUMBER() OVER (PARTITION BY task_id ORDER BY id) AS rank
+            FROM access_log
+            WHERE agent_id = ?
+              AND task_id IS NOT NULL
+              AND task_outcome IS NOT NULL
+              AND target_table = 'memories'
+              AND created_at >= datetime('now', ?)
+            """,
+            (agent_id, f"-{period_days} days"),
+        ).fetchall()
+
+        top_k = [r for r in rows if r["rank"] <= k]
+        if not top_k:
+            return None
+
+        hits = 0
+        for r in top_k:
+            if r["retrieval_contributed"] is not None:
+                hits += r["retrieval_contributed"]
+            elif r["task_outcome"] == "success":
+                hits += 1
+
+        return hits / len(top_k)
+    finally:
+        conn.close()
+
+
+def run_calibration_pass(
+    agent_id: str,
+    period_days: int = 30,
+    db_path: str = None,
+) -> dict:
+    """
+    Compute and persist a calibration snapshot for the given agent/period.
+
+    Writes a row to memory_outcome_calibration and returns the computed dict.
+    """
+    conn = _get_db(db_path)
+    try:
+        # Count tasks in period
+        task_counts = conn.execute(
+            """
+            SELECT
+                COUNT(DISTINCT task_id) AS total,
+                COUNT(DISTINCT CASE WHEN target_table = 'memories' THEN task_id END) AS used_memory
+            FROM access_log
+            WHERE agent_id = ?
+              AND task_id IS NOT NULL
+              AND task_outcome IS NOT NULL
+              AND created_at >= datetime('now', ?)
+            """,
+            (agent_id, f"-{period_days} days"),
+        ).fetchone()
+
+        total_tasks = task_counts["total"] or 0
+        tasks_used_memory = task_counts["used_memory"] or 0
+
+        lift = compute_memory_lift(period_days=period_days, db_path=db_path)
+        brier = compute_brier_score(agent_id=agent_id, period_days=period_days, db_path=db_path)
+        p5 = compute_precision_at_k(agent_id=agent_id, k=5, period_days=period_days, db_path=db_path)
+
+        now = _now_iso()
+        period_start = (
+            datetime.now(timezone.utc) - timedelta(days=period_days)
+        ).strftime("%Y-%m-%dT%H:%M:%S")
+
+        conn.execute(
+            """
+            INSERT INTO memory_outcome_calibration
+              (agent_id, period_start, period_end, total_tasks, tasks_used_memory,
+               success_with_memory, success_without_memory, brier_score, p_at_5, computed_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                agent_id,
+                period_start,
+                now,
+                total_tasks,
+                tasks_used_memory,
+                lift["with_memory_success_rate"],
+                lift["without_memory_success_rate"],
+                brier,
+                p5,
+                now,
+            ),
+        )
+        conn.commit()
+
+        return {
+            "agent_id": agent_id,
+            "period_days": period_days,
+            "period_start": period_start,
+            "period_end": now,
+            "total_tasks": total_tasks,
+            "tasks_used_memory": tasks_used_memory,
+            "success_with_memory": lift["with_memory_success_rate"],
+            "success_without_memory": lift["without_memory_success_rate"],
+            "lift_pp": lift["lift_pp"],
+            "brier_score": brier,
+            "p_at_5": p5,
+        }
+    finally:
+        conn.close()

--- a/src/agentmemory/lib/quantum_retrieval.py
+++ b/src/agentmemory/lib/quantum_retrieval.py
@@ -1,0 +1,479 @@
+"""
+quantum_retrieval.py — Phase-Aware Quantum Amplitude Scorer
+
+Production module extracted from COS-383 / COS-392 research
+(quantum_amplitude_scorer_v2.py + phase_inference.py).
+
+Key API:
+    quantum_rerank(candidates, db_path, benchmark=False) -> list[dict]
+    compute_amplitude(confidence, confidence_phase) -> complex
+    compute_interference_score(query_amplitude, candidate_amplitudes, graph_edges) -> float
+    quantum_amplitude_score(query_embedding, candidate_memories, ...) -> list[tuple[str, float]]
+"""
+
+from __future__ import annotations
+
+import cmath
+import math
+import sqlite3
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+_DEFAULT_DB = Path.home() / "agentmemory" / "db" / "brain.db"
+
+_INTERFERENCE_STRENGTH = 0.2   # graph interference weight
+_DECOHERENCE_RATE = 0.05       # per-hop decay
+_RECENCY_DECAY_K = 0.1         # normal memories (per day)
+_RECENCY_DECAY_K_LONG = 0.01   # long/permanent memories
+
+_PHASE_BY_RELATION: Dict[str, float] = {
+    "semantic_similar":  0.0,
+    "supports":          0.0,
+    "co_referenced":     0.0,
+    "topical_tag":       0.0,
+    "contradicts":       math.pi,
+    "derived_from":      math.pi / 4,
+    "supersedes":        math.pi,
+    "causes":            math.pi / 6,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public primitives (matches spec signatures)
+# ---------------------------------------------------------------------------
+
+def compute_amplitude(confidence: float, confidence_phase: float) -> complex:
+    """
+    α_i = sqrt(confidence) × exp(i × confidence_phase)
+
+    Args:
+        confidence: Memory confidence [0, 1]
+        confidence_phase: Phase angle in radians [0, 2π)
+
+    Returns:
+        Complex amplitude
+    """
+    magnitude = math.sqrt(max(0.0, confidence))
+    return magnitude * cmath.exp(1j * confidence_phase)
+
+
+def compute_interference_score(
+    query_amplitude: complex,
+    candidate_amplitudes: List[complex],
+    graph_edges: List[Tuple],  # (source_id, target_id, weight)
+) -> float:
+    """
+    Born rule: |<query | Σ amplitudes>|²
+
+    The interference score is the squared magnitude of the inner product
+    between the query amplitude and the superposition of candidate amplitudes,
+    modulated by graph edge weights.
+
+    Args:
+        query_amplitude: Query's complex amplitude
+        candidate_amplitudes: List of candidate complex amplitudes
+        graph_edges: List of (source_id, target_id, weight) tuples
+
+    Returns:
+        Interference score [0, ∞), typically in [0, 1]
+    """
+    if not candidate_amplitudes:
+        return abs(query_amplitude) ** 2
+
+    # Build edge weight index (symmetric)
+    edge_weights: Dict[Tuple, float] = {}
+    for src, tgt, w in graph_edges:
+        edge_weights[(src, tgt)] = float(w)
+        edge_weights[(tgt, src)] = float(w)
+
+    # Superposition with interference (weighted sum)
+    superposition = complex(0, 0)
+    for amp in candidate_amplitudes:
+        superposition += amp
+
+    # Inner product (conjugate of query dotted with superposition)
+    inner = query_amplitude.conjugate() * superposition
+
+    # Born rule
+    return abs(inner) ** 2
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _load_knowledge_graph(conn: sqlite3.Connection) -> Dict[int, List[Tuple[int, float]]]:
+    graph: Dict[int, List[Tuple[int, float]]] = defaultdict(list)
+    try:
+        rows = conn.execute("""
+            SELECT source_memory_id, target_memory_id, weight
+            FROM knowledge_edges WHERE deleted_at IS NULL
+        """).fetchall()
+        for src, tgt, w in rows:
+            w = float(w) if w else 1.0
+            graph[src].append((tgt, w))
+            graph[tgt].append((src, w))
+    except sqlite3.OperationalError:
+        pass
+    return dict(graph)
+
+
+def _load_phase_map(conn: sqlite3.Connection) -> Dict[int, float]:
+    phase_map: Dict[int, float] = {}
+    try:
+        rows = conn.execute("""
+            SELECT id, confidence_phase FROM memories
+            WHERE retired_at IS NULL AND confidence_phase IS NOT NULL
+        """).fetchall()
+        for mem_id, phase in rows:
+            phase_map[int(mem_id)] = float(phase) if phase else 0.0
+    except sqlite3.OperationalError:
+        pass
+    return phase_map
+
+
+def _recency_score(
+    last_recalled_at: Optional[str],
+    created_at: Optional[str],
+    temporal_class: Optional[str] = None,
+) -> float:
+    decay_k = _RECENCY_DECAY_K_LONG if temporal_class in ("long", "permanent") else _RECENCY_DECAY_K
+    ref = last_recalled_at or created_at
+    if not ref:
+        return 1.0
+    try:
+        ts = ref.strip()
+        if ts.endswith("Z"):
+            ts = ts[:-1] + "+00:00"
+        if " " in ts and "T" not in ts:
+            ts = ts.replace(" ", "T", 1)
+        dt = datetime.fromisoformat(ts)
+        if dt.tzinfo is None:
+            now = datetime.now(timezone.utc).replace(tzinfo=None)
+        else:
+            now = datetime.now(timezone.utc)
+            dt = dt.astimezone(timezone.utc)
+        days = max(0.0, (now - dt).total_seconds() / 86400.0)
+        return math.exp(-decay_k * days)
+    except Exception:
+        return 1.0
+
+
+def _compute_memory_quantum_score(
+    mem_id: int,
+    similarity: float,
+    confidence: float,
+    confidence_phase: float,
+    temporal_class: Optional[str],
+    last_recalled_at: Optional[str],
+    created_at: Optional[str],
+    conn: sqlite3.Connection,
+    graph: Dict[int, List[Tuple[int, float]]],
+    phase_map: Dict[int, float],
+) -> float:
+    """Core quantum salience score for a single memory."""
+
+    # ── Base amplitude (confidence + phase + similarity) ──────────────────
+    base_amp = compute_amplitude(confidence, confidence_phase)
+    sim_phase = math.pi * similarity
+    sim_boost = math.exp(1j * sim_phase)  # not used below but kept for clarity
+    magnitude = min(1.0, abs(base_amp) * (1.0 + 0.3 * similarity))
+    phase_angle = cmath.phase(base_amp) + sim_phase * 0.3
+    mem_amplitude = magnitude * cmath.exp(1j * phase_angle)
+
+    # ── Graph interference ─────────────────────────────────────────────────
+    neighbors = graph.get(mem_id, [])
+    interference_sum = complex(0, 0)
+    if neighbors:
+        neighbor_ids = [nid for nid, _ in neighbors]
+        placeholders = ",".join("?" * len(neighbor_ids))
+        try:
+            nb_rows = conn.execute(
+                f"SELECT id, confidence, confidence_phase FROM memories "
+                f"WHERE id IN ({placeholders}) AND retired_at IS NULL",
+                neighbor_ids,
+            ).fetchall()
+        except Exception:
+            nb_rows = []
+
+        edge_map = {nid: w for nid, w in neighbors}
+        for nb_id, nb_conf, nb_phase_raw in nb_rows:
+            nb_phase = phase_map.get(nb_id, float(nb_phase_raw or 0.0))
+            nb_amp = compute_amplitude(float(nb_conf or 0.5), nb_phase)
+            weight = edge_map.get(nb_id, 1.0)
+
+            # Destructive vs constructive based on relation type
+            try:
+                rel_row = conn.execute(
+                    "SELECT relation_type FROM knowledge_edges "
+                    "WHERE (source_id=? AND target_id=?) OR (source_id=? AND target_id=?) LIMIT 1",
+                    (mem_id, nb_id, nb_id, mem_id),
+                ).fetchone()
+                relation = rel_row[0] if rel_row else "co_referenced"
+            except Exception:
+                relation = "co_referenced"
+
+            phase_diff = (confidence_phase - nb_phase) % (2 * math.pi)
+            target = math.pi if relation == "contradicts" else 0.0
+            phase_err = (phase_diff - target) % (2 * math.pi)
+            if phase_err > math.pi:
+                phase_err = 2 * math.pi - phase_err
+            alignment = math.cos(phase_err)
+
+            contribution = nb_amp * weight * alignment * math.exp(-_DECOHERENCE_RATE)
+            interference_sum += contribution
+
+        if len(nb_rows) > 0:
+            interference_sum /= len(nb_rows)
+
+    total_amp = mem_amplitude + _INTERFERENCE_STRENGTH * interference_sum
+
+    # ── Born rule ──────────────────────────────────────────────────────────
+    probability = abs(total_amp) ** 2
+
+    # ── Combine with classical signals ─────────────────────────────────────
+    confidence_mod = 0.7 + 0.3 * confidence
+    combined = (similarity + 0.2 * probability) * confidence_mod
+    recency = _recency_score(last_recalled_at, created_at, temporal_class)
+
+    return max(0.0, min(1.0, combined * recency))
+
+
+# ---------------------------------------------------------------------------
+# Public: quantum_amplitude_score (spec interface)
+# ---------------------------------------------------------------------------
+
+def quantum_amplitude_score(
+    query_embedding: List[float],
+    candidate_memories: List[dict],
+    k_interference: int = 5,
+    use_graph: bool = True,
+    db_path: str = str(_DEFAULT_DB),
+) -> List[Tuple[str, float]]:
+    """
+    Phase-aware quantum amplitude re-ranking.
+
+    Args:
+        query_embedding: Query embedding vector (used for cosine similarity when
+                         candidate embedding is available; falls back to stored similarity)
+        candidate_memories: List of dicts with keys:
+                            id, content, confidence, confidence_phase, embedding (optional)
+                            Also accepts: rrf_score, final_score, similarity as pre-computed sims
+        k_interference: Max neighbors to compute cross-interference with
+        use_graph: Use knowledge_edges for graph interference amplification
+        db_path: Path to brain.db
+
+    Returns:
+        List of (memory_id_str, quantum_score) sorted descending by score
+    """
+    import numpy as np
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    graph = _load_knowledge_graph(conn) if use_graph else {}
+    phase_map = _load_phase_map(conn)
+
+    # Normalise query embedding for cosine sim
+    q_arr = None
+    if query_embedding:
+        q_np = np.array(query_embedding, dtype=np.float32)
+        q_norm = np.linalg.norm(q_np)
+        if q_norm > 0:
+            q_arr = q_np / q_norm
+
+    scored: List[Tuple[str, float]] = []
+    for mem in candidate_memories:
+        mem_id = int(mem["id"])
+        confidence = float(mem.get("confidence") or 0.5)
+        confidence_phase = phase_map.get(mem_id, float(mem.get("confidence_phase") or 0.0))
+
+        # Compute similarity
+        sim = 0.5  # neutral default
+        if q_arr is not None and mem.get("embedding"):
+            try:
+                m_np = np.frombuffer(mem["embedding"], dtype=np.float32)
+                m_norm = np.linalg.norm(m_np)
+                if m_norm > 0:
+                    sim = float(np.dot(q_arr, m_np / m_norm))
+                    sim = max(0.0, min(1.0, (sim + 1.0) / 2.0))  # cosine [-1,1] → [0,1]
+            except Exception:
+                pass
+        elif "rrf_score" in mem:
+            sim = float(mem["rrf_score"])
+        elif "final_score" in mem:
+            sim = float(mem["final_score"])
+        elif "similarity" in mem:
+            sim = float(mem["similarity"])
+
+        q_score = _compute_memory_quantum_score(
+            mem_id=mem_id,
+            similarity=sim,
+            confidence=confidence,
+            confidence_phase=confidence_phase,
+            temporal_class=mem.get("temporal_class"),
+            last_recalled_at=mem.get("last_recalled_at"),
+            created_at=mem.get("created_at"),
+            conn=conn,
+            graph=graph,
+            phase_map=phase_map,
+        )
+        scored.append((str(mem_id), q_score))
+
+    conn.close()
+    scored.sort(key=lambda x: x[1], reverse=True)
+    if k_interference < len(scored):
+        scored = scored[:k_interference]
+    return scored
+
+
+# ---------------------------------------------------------------------------
+# Public: quantum_rerank (brainctl/MCP convenience wrapper)
+# ---------------------------------------------------------------------------
+
+def quantum_rerank(
+    candidates: List[dict],
+    db_path: str = str(_DEFAULT_DB),
+    benchmark: bool = False,
+    min_salience: float = 0.0,
+) -> List[dict]:
+    """
+    Re-rank a list of brainctl memory dicts using quantum amplitude scoring.
+
+    Transparent: preserves all existing fields, adds `quantum_score`.
+    If `benchmark=True`, also preserves `classical_score` for comparison.
+
+    Args:
+        candidates: Memory dicts as returned by brainctl search (with final_score, etc.)
+        db_path: Path to brain.db
+        benchmark: If True, add `classical_score` field for comparison
+        min_salience: Drop candidates below this quantum score (0 = keep all)
+
+    Returns:
+        Re-ranked list sorted by quantum_score descending, with original fields intact
+    """
+    if not candidates:
+        return candidates
+
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+    except Exception:
+        return candidates
+
+    try:
+        graph = _load_knowledge_graph(conn)
+        phase_map = _load_phase_map(conn)
+    except Exception:
+        conn.close()
+        return candidates
+
+    result = []
+    for mem in candidates:
+        mem_id_raw = mem.get("id")
+        if mem_id_raw is None:
+            result.append(mem)
+            continue
+
+        try:
+            mem_id = int(mem_id_raw)
+        except (ValueError, TypeError):
+            result.append(mem)
+            continue
+
+        confidence = float(mem.get("confidence") or 0.5)
+        confidence_phase = phase_map.get(mem_id, 0.0)
+        # Use best available pre-computed similarity
+        sim = float(mem.get("final_score") or mem.get("rrf_score") or 0.0)
+
+        try:
+            q_score = _compute_memory_quantum_score(
+                mem_id=mem_id,
+                similarity=sim,
+                confidence=confidence,
+                confidence_phase=confidence_phase,
+                temporal_class=mem.get("temporal_class"),
+                last_recalled_at=mem.get("last_recalled_at"),
+                created_at=mem.get("created_at"),
+                conn=conn,
+                graph=graph,
+                phase_map=phase_map,
+            )
+        except Exception:
+            q_score = sim  # fall back to classical
+
+        if q_score < min_salience:
+            continue
+
+        updated = dict(mem)
+        if benchmark:
+            updated["classical_score"] = round(float(mem.get("final_score") or 0.0), 6)
+        updated["quantum_score"] = round(q_score, 6)
+        updated["confidence_phase"] = round(confidence_phase, 4)
+        updated["final_score"] = round(q_score, 8)  # replace final_score so downstream sort works
+        result.append(updated)
+
+    conn.close()
+
+    result.sort(key=lambda x: x.get("quantum_score", 0.0), reverse=True)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Phase update hook (post-recall, delta rule from phase_inference)
+# ---------------------------------------------------------------------------
+
+def update_phase_after_recall(
+    memory_id: int,
+    db_path: str = str(_DEFAULT_DB),
+    delta: float = 0.05,
+) -> bool:
+    """
+    Update confidence_phase for a recalled memory using a simple delta rule.
+
+    Each successful recall nudges the phase toward the constructive value (0)
+    to increase future interference amplification.
+
+    Args:
+        memory_id: Memory that was recalled
+        db_path: Path to brain.db
+        delta: Phase shift per recall event
+
+    Returns:
+        True if updated, False if memory not found or column missing
+    """
+    try:
+        conn = sqlite3.connect(db_path)
+        cur = conn.execute(
+            "SELECT confidence_phase FROM memories WHERE id=? AND retired_at IS NULL",
+            (memory_id,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            conn.close()
+            return False
+
+        phase = float(row[0] or 0.0)
+        # Delta rule: nudge phase toward 0 (constructive interference) by delta
+        # Using circular arithmetic: reduce absolute phase
+        if phase > math.pi:
+            phase = phase + delta  # wraps toward 0 from the high side
+        else:
+            phase = max(0.0, phase - delta)
+        phase = phase % (2 * math.pi)
+
+        conn.execute(
+            "UPDATE memories SET confidence_phase=? WHERE id=?",
+            (phase, memory_id),
+        )
+        conn.commit()
+        conn.close()
+        return True
+    except Exception:
+        return False

--- a/src/agentmemory/mcp_server.py
+++ b/src/agentmemory/mcp_server.py
@@ -27,6 +27,9 @@ from typing import Any
 
 from agentmemory.lib.mcp_helpers import now_iso, safe_fts
 from agentmemory.paths import get_db_path
+# Import the canonical surprise scorer from _impl.py — see bug-fix note
+# below at the former _surprise_score_mcp callsite.
+from agentmemory._impl import _surprise_score
 logger = logging.getLogger(__name__)
 from mcp.server import Server
 
@@ -144,13 +147,20 @@ def _builtin_classify_intent(query):
                                  'Standard search results',
                                  ['memories', 'events', 'context'])
 
-# Quantum amplitude scorer (optional re-ranking)
+# Quantum amplitude scorer (optional re-ranking).
+# Ships in-tree as of 2.4.9 under agentmemory.lib.quantum_retrieval so
+# PyPI installs work without the legacy ~/bin/lib drop. Fall through to
+# the old site-path for users running an old install layout; audit I19.
 try:
-    sys.path.insert(0, str(Path.home() / "bin" / "lib"))
-    from quantum_retrieval import quantum_rerank as _quantum_rerank
+    from agentmemory.lib.quantum_retrieval import quantum_rerank as _quantum_rerank
     _QUANTUM_AVAILABLE = True
 except Exception:
-    _QUANTUM_AVAILABLE = False
+    try:
+        sys.path.insert(0, str(Path.home() / "bin" / "lib"))
+        from quantum_retrieval import quantum_rerank as _quantum_rerank
+        _QUANTUM_AVAILABLE = True
+    except Exception:
+        _QUANTUM_AVAILABLE = False
 
 # ---------------------------------------------------------------------------
 # Constants (same as brainctl)
@@ -384,83 +394,15 @@ def _compute_pii_mcp(db, memory_id: int) -> float:
     return min(1.0, max(0.0, bayesian_strength * recall_weight * temporal_weight))
 
 
-def _surprise_score_mcp(db, content: str, blob=None):
-    """Compute surprise score for a candidate memory (MCP path).
-
-    Returns (surprise: float, method: str) where surprise in [0, 1].
-    1.0 = maximally novel, 0.0 = exact duplicate.
-    """
-    # Method 1: Cosine similarity via embeddings
-    if blob:
-        try:
-            db_vec = _get_vec_db()
-            if db_vec:
-                try:
-                    rows = db_vec.execute(
-                        "SELECT rowid FROM vec_memories WHERE embedding MATCH ? AND k=?",
-                        (blob, 5)
-                    ).fetchall()
-                    if rows:
-                        cand_n = len(blob) // 4
-                        cand_vec = list(struct.unpack(f"{cand_n}f", blob[:cand_n * 4]))
-                        max_sim = 0.0
-                        for row in rows:
-                            e = db_vec.execute(
-                                "SELECT vector FROM embeddings WHERE source_table='memories' AND source_id=?",
-                                (row[0] if isinstance(row, tuple) else row["rowid"],)
-                            ).fetchone()
-                            if e:
-                                v_bytes = bytes(e[0] if isinstance(e, tuple) else e["vector"])
-                                n2 = len(v_bytes) // 4
-                                v2 = list(struct.unpack(f"{n2}f", v_bytes[:n2 * 4]))
-                                dot = sum(a * b for a, b in zip(cand_vec, v2))
-                                import math as _sm
-                                na = _sm.sqrt(sum(x * x for x in cand_vec))
-                                nb = _sm.sqrt(sum(x * x for x in v2))
-                                if na > 0 and nb > 0:
-                                    sim = max(-1.0, min(1.0, dot / (na * nb)))
-                                    max_sim = max(max_sim, sim)
-                        return round(max(0.0, min(1.0, 1.0 - max_sim)), 4), "cosine"
-                    else:
-                        return 1.0, "cosine_no_neighbors"
-                finally:
-                    db_vec.close()
-        except Exception:
-            pass
-
-    # Method 2: FTS5 word overlap
-    try:
-        words = set(content.lower().split())
-        if not words:
-            return 1.0, "empty"
-        query_words = list(words)[:20]
-        fts_query = _safe_fts(" ".join(query_words))
-        if not fts_query:
-            return 1.0, "fts5_no_query"
-        rows = db.execute(
-            "SELECT content FROM memories WHERE retired_at IS NULL AND content LIKE ? LIMIT 5",
-            (f"%{' '.join(query_words[:5])}%",)
-        ).fetchall()
-        if not rows:
-            return 1.0, "fts5_no_matches"
-        max_overlap = 0.0
-        for row in rows:
-            existing_words = set(row["content"].lower().split())
-            if not existing_words:
-                continue
-            intersection = words & existing_words
-            union = words | existing_words
-            overlap = len(intersection) / len(union) if union else 0.0
-            max_overlap = max(max_overlap, overlap)
-        if max_overlap > 0.9:
-            surprise = 0.1 + (1.0 - max_overlap) * 2.0
-        elif max_overlap < 0.1:
-            surprise = 0.9 + (0.1 - max_overlap)
-        else:
-            surprise = 1.0 - max_overlap
-        return round(max(0.0, min(1.0, surprise)), 4), "fts5"
-    except Exception:
-        return 0.7, "fts5_error"
+# _surprise_score_mcp removed in 2.4.9 — it was a stale copy of
+# _impl._surprise_score from the era before the 2.2.3 neutral-fallback
+# fix. The 2026-04-18 audit's H5 finding patched _impl.py but left this
+# MCP-path duplicate returning (1.0, "fts5_no_matches") / (1.0, "cosine_no_neighbors")
+# instead of (0.5, "fts5_no_matches_neutral") / the vec-fallback chain.
+# The MCP path is the dominant write path in practice, so the fix has
+# real effect on W(m) gate calibration. We now import the canonical
+# scorer directly from _impl.py so future scoring changes land everywhere.
+# Regression test lives in tests/test_mcp_surprise_score_parity.py.
 
 
 # Source trust weights for the W(m) gate multiplier (issue #24).
@@ -507,7 +449,7 @@ def tool_memory_add(agent_id: str, content: str, category: str, scope: str = "gl
     # _embed_safe already catches network errors and returns None.
     blob = _embed_safe(content)
     try:
-        surprise, surprise_method = _surprise_score_mcp(db, content, blob=blob)
+        surprise, surprise_method = _surprise_score(db, content, blob=blob)
     except Exception:
         surprise, surprise_method = 0.7, "error"
 
@@ -2060,16 +2002,16 @@ def tool_belief_collapse(
             evaluate_coherence, is_superposed, check_and_collapse_on_time,
         )
     except ImportError as e:
-        return {"error": f"collapse_mechanics import failed: {e}"}
+        return {"ok": False, "error": f"collapse_mechanics import failed: {e}"}
 
     if action == "collapse":
         if not belief_id:
-            return {"error": "belief_id required for collapse action"}
+            return {"ok": False, "error": "belief_id required for collapse action"}
         if not trigger_type:
-            return {"error": "trigger_type required for collapse action"}
+            return {"ok": False, "error": "trigger_type required for collapse action"}
         valid_triggers = ("task_checkout", "direct_query", "evidence_threshold", "time_decoherence")
         if trigger_type not in valid_triggers:
-            return {"error": f"Unknown trigger_type: {trigger_type}. Use: {', '.join(valid_triggers)}"}
+            return {"ok": False, "error": f"Unknown trigger_type: {trigger_type}. Use: {', '.join(valid_triggers)}"}
         collapsed = force_collapse(
             db_path=None,
             agent_id=agent_id,
@@ -2088,7 +2030,7 @@ def tool_belief_collapse(
 
     elif action == "check":
         if not belief_id:
-            return {"error": "belief_id required for check action"}
+            return {"ok": False, "error": "belief_id required for check action"}
         coherence = evaluate_coherence(belief_id)
         superposed = is_superposed(belief_id)
         auto_collapsed = None
@@ -2102,7 +2044,7 @@ def tool_belief_collapse(
             "auto_collapsed": auto_collapsed,
         }
 
-    return {"error": f"Unknown action: {action}. Use: collapse, log, stats, check"}
+    return {"ok": False, "error": f"Unknown action: {action}. Use: collapse, log, stats, check"}
 
 
 def tool_access_log_annotate(
@@ -2111,18 +2053,22 @@ def tool_access_log_annotate(
     outcome: str,
 ) -> dict:
     """Annotate access_log rows for a completed task with its outcome."""
-    import sys as _sys
-    from pathlib import Path as _Path
-    _sys.path.insert(0, str(_Path.home() / "bin" / "lib"))
+    # Prefer the in-tree copy (2.4.9+); fall back to legacy ~/bin/lib.
     try:
-        from outcome_eval import annotate_task_retrieval
-    except ImportError as e:
-        return {"error": f"outcome_eval import failed: {e}"}
+        from agentmemory.lib.outcome_eval import annotate_task_retrieval
+    except ImportError:
+        import sys as _sys
+        from pathlib import Path as _Path
+        _sys.path.insert(0, str(_Path.home() / "bin" / "lib"))
+        try:
+            from outcome_eval import annotate_task_retrieval
+        except ImportError as e:
+            return {"ok": False, "error": f"outcome_eval import failed: {e}"}
     try:
         n = annotate_task_retrieval(task_id=task_id, agent_id=agent_id, outcome=outcome)
         return {"ok": True, "task_id": task_id, "outcome": outcome, "agent_id": agent_id, "rows_annotated": n}
     except ValueError as e:
-        return {"error": str(e)}
+        return {"ok": False, "error": str(e)}
 
 
 def tool_resolve_conflict(
@@ -2135,17 +2081,25 @@ def tool_resolve_conflict(
     threshold: float = 0.05,
 ) -> dict:
     """AGM credibility-weighted belief conflict resolution."""
-    import sys as _sys
-    from pathlib import Path as _Path
-    _sys.path.insert(0, str(_Path.home() / "bin" / "lib"))
+    # Prefer the in-tree copy (2.4.9+); fall back to legacy ~/bin/lib.
     try:
-        from belief_revision import (
+        from agentmemory.lib.belief_revision import (
             resolve_conflict as _resolve,
             list_conflicts as _list_fn,
             auto_resolve as _auto,
         )
-    except ImportError as e:
-        return {"error": f"belief_revision import failed: {e}"}
+    except ImportError:
+        import sys as _sys
+        from pathlib import Path as _Path
+        _sys.path.insert(0, str(_Path.home() / "bin" / "lib"))
+        try:
+            from belief_revision import (
+                resolve_conflict as _resolve,
+                list_conflicts as _list_fn,
+                auto_resolve as _auto,
+            )
+        except ImportError as e:
+            return {"ok": False, "error": f"belief_revision import failed: {e}"}
 
     db_path = str(DB_PATH)
 
@@ -2169,7 +2123,7 @@ def tool_resolve_conflict(
         }
 
     if conflict_id is None:
-        return {"error": "Provide conflict_id, list_conflicts=true, or auto=true"}
+        return {"ok": False, "error": "Provide conflict_id, list_conflicts=true, or auto=true"}
 
     return _resolve(
         conflict_id=conflict_id,

--- a/src/agentmemory/mcp_tools_knowledge.py
+++ b/src/agentmemory/mcp_tools_knowledge.py
@@ -387,7 +387,7 @@ def _report_entity_json(conn: sqlite3.Connection, name: str, limit: int) -> dict
         (f"%{name}%",),
     ).fetchone()
     if not row:
-        return {"error": f"Entity '{name}' not found"}
+        return {"ok": False, "error": f"Entity '{name}' not found"}
 
     ent = dict(row)
     obs: list = []

--- a/src/agentmemory/mcp_tools_reflexion.py
+++ b/src/agentmemory/mcp_tools_reflexion.py
@@ -454,11 +454,14 @@ def handle_reflexion_retire(arguments: dict) -> dict:
 
 def handle_outcome_annotate(arguments: dict) -> dict:
     try:
-        import sys
-        sys.path.insert(0, str(Path.home() / "bin" / "lib"))
-        from outcome_eval import annotate_task_retrieval
+        from agentmemory.lib.outcome_eval import annotate_task_retrieval
     except ImportError:
-        return {"ok": False, "error": "outcome_eval module not available"}
+        try:
+            import sys
+            sys.path.insert(0, str(Path.home() / "bin" / "lib"))
+            from outcome_eval import annotate_task_retrieval
+        except ImportError:
+            return {"ok": False, "error": "outcome_eval module not available"}
 
     task_id = arguments.get("task_id")
     if not task_id:
@@ -477,11 +480,17 @@ def handle_outcome_annotate(arguments: dict) -> dict:
 
 def handle_outcome_report(arguments: dict) -> dict:
     try:
-        import sys
-        sys.path.insert(0, str(Path.home() / "bin" / "lib"))
-        from outcome_eval import compute_memory_lift, compute_brier_score, compute_precision_at_k, run_calibration_pass
+        from agentmemory.lib.outcome_eval import (
+            compute_memory_lift, compute_brier_score,
+            compute_precision_at_k, run_calibration_pass,
+        )
     except ImportError:
-        return {"ok": False, "error": "outcome_eval module not available"}
+        try:
+            import sys
+            sys.path.insert(0, str(Path.home() / "bin" / "lib"))
+            from outcome_eval import compute_memory_lift, compute_brier_score, compute_precision_at_k, run_calibration_pass
+        except ImportError:
+            return {"ok": False, "error": "outcome_eval module not available"}
 
     agent_id = arguments.get("agent_id") or os.environ.get("AGENT_ID", "unknown")
     period_raw = arguments.get("period")

--- a/src/agentmemory/merge.py
+++ b/src/agentmemory/merge.py
@@ -577,6 +577,17 @@ def merge(
         raise FileNotFoundError(f"Source DB not found: {source_path}")
     if not Path(target_path).exists():
         raise FileNotFoundError(f"Target DB not found: {target_path}")
+    # Guard self-merge explicitly. Before 2.4.9 the ATTACH DATABASE call
+    # would succeed, then BEGIN IMMEDIATE on the target would fail with
+    # "database is locked" (same file is already being written from the
+    # main connection). That error message is unhelpful for the user's
+    # real problem — they pointed source and target at the same file.
+    # Audit I17.
+    if Path(source_path).resolve() == Path(target_path).resolve():
+        raise ValueError(
+            f"Cannot merge a database with itself: source and target "
+            f"resolve to the same path ({Path(source_path).resolve()})."
+        )
 
     tables_to_merge = tables if tables is not None else list(_DEFAULT_TABLES)
 

--- a/src/agentmemory/paths.py
+++ b/src/agentmemory/paths.py
@@ -11,7 +11,20 @@ def get_brain_home() -> Path:
 
 
 def get_db_path() -> Path:
-    return Path(os.environ.get("BRAIN_DB", str(get_brain_home() / "db" / "brain.db"))).expanduser()
+    # Go-forward canonical env var is BRAINCTL_DB (matches the family —
+    # BRAINCTL_HOME, BRAINCTL_BLOBS_DIR, BRAINCTL_BACKUPS_DIR). BRAIN_DB is
+    # the historical name kept as a deprecated alias so users with
+    # existing plugin configs keep working. BRAINCTL_DB wins when both
+    # are set. The goose / pi / opencode / gemini-cli plugins all ship
+    # BRAINCTL_DB in their manifests; the claude-code / openclaw / cursor
+    # / codex / eliza plugins still use BRAIN_DB and will be updated in
+    # subsequent docs passes — no config change required for their users.
+    default = str(get_brain_home() / "db" / "brain.db")
+    return Path(
+        os.environ.get("BRAINCTL_DB")
+        or os.environ.get("BRAIN_DB")
+        or default
+    ).expanduser()
 
 
 def get_blobs_dir() -> Path:

--- a/tests/test_audit_2_4_9_regressions.py
+++ b/tests/test_audit_2_4_9_regressions.py
@@ -1,0 +1,100 @@
+"""Regression locks for the 2.4.9 audit follow-up fixes.
+
+These tests don't exercise behavior that any other test covers — they
+exist so a later "simplify" pass can't silently revert the fixes.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# --- I9: cmd_doctor reflects health in exit code + ok flag ---------------
+
+def test_cmd_doctor_exits_nonzero_on_issues(tmp_path, monkeypatch, capsys):
+    import argparse
+    import json as _json
+    from agentmemory import _impl
+
+    # Fresh virgin DB guaranteed to surface at least one issue
+    # (schema_versions empty but init_schema has late-migration columns).
+    db = tmp_path / "brain.db"
+    from agentmemory.brain import Brain
+
+    import os
+    os.environ["BRAINCTL_SILENT_MIGRATIONS"] = "1"
+    Brain(str(db))
+    os.environ.pop("BRAINCTL_SILENT_MIGRATIONS", None)
+
+    monkeypatch.setattr(_impl, "DB_PATH", db)
+    monkeypatch.setattr(
+        _impl, "get_db", lambda *a, **k: sqlite3.connect(str(db))
+    )
+
+    args = argparse.Namespace(json=True)
+    with pytest.raises(SystemExit) as exc:
+        _impl.cmd_doctor(args)
+    assert exc.value.code == 1, "doctor must exit 1 when issues present"
+
+    payload = _json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["healthy"] is False
+    assert len(payload["issues"]) >= 1
+
+
+# --- I16: federation LIKE escaping ---------------------------------------
+
+def test_federation_escape_like_prevents_wildcard_injection():
+    from agentmemory.federation import _escape_like
+
+    assert _escape_like("api_key") == "api\\_key"
+    assert _escape_like("100%") == "100\\%"
+    assert _escape_like("a\\b") == "a\\\\b"
+
+    # Behavioral: escaped + ESCAPE '\' must not treat `_` as wildcard.
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE t (c TEXT)")
+    conn.executemany(
+        "INSERT INTO t(c) VALUES (?)",
+        [("api_key",), ("apikey",), ("api-key",), ("100%",), ("100",)],
+    )
+
+    unescaped = [r[0] for r in conn.execute(
+        "SELECT c FROM t WHERE c LIKE ?", ("%api_key%",)
+    ).fetchall()]
+    escaped = [r[0] for r in conn.execute(
+        "SELECT c FROM t WHERE c LIKE ? ESCAPE '\\'",
+        (f"%{_escape_like('api_key')}%",),
+    ).fetchall()]
+    # Pre-fix behavior: `_` is a wildcard, matches `api-key` too.
+    assert "api-key" in unescaped
+    # Post-fix: literal `_`, matches only the real underscore string.
+    assert escaped == ["api_key"]
+
+
+# --- I17: merge guards against source == target --------------------------
+
+def test_merge_rejects_self_merge(tmp_path):
+    from agentmemory import merge
+    from agentmemory.brain import Brain
+
+    db = tmp_path / "self.db"
+    Brain(db_path=str(db))
+
+    # Direct equality.
+    with pytest.raises(ValueError, match="merge a database with itself"):
+        merge.merge(source_path=str(db), target_path=str(db))
+
+    # Path-equivalent (resolved form).
+    with pytest.raises(ValueError, match="merge a database with itself"):
+        merge.merge(
+            source_path=str(db),
+            target_path=str(db.parent / "." / "self.db"),
+        )

--- a/tests/test_mcp_surprise_score_parity.py
+++ b/tests/test_mcp_surprise_score_parity.py
@@ -1,0 +1,65 @@
+"""Regression test for the MCP surprise-score parity fix (2.4.9, audit I7).
+
+The 2026-04-18 audit found that `mcp_server._surprise_score_mcp` was a
+stale copy of `_impl._surprise_score` that missed the 2.2.3
+neutral-fallback fix: it still returned `(1.0, "fts5_no_matches")` when
+FTS5 found no neighbors, inflating W(m) novelty on the dominant MCP
+write path. The fix deletes the duplicate and imports the canonical
+scorer. This test locks the parity so the two paths can't drift again.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from agentmemory import mcp_server
+from agentmemory._impl import _surprise_score as impl_surprise_score
+from agentmemory.brain import Brain
+
+
+@pytest.fixture
+def fresh_db(tmp_path):
+    db_path = tmp_path / "brain.db"
+    Brain(db_path=str(db_path))
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    yield conn
+    conn.close()
+
+
+def test_mcp_server_imports_canonical_surprise_score():
+    # The module no longer defines a local copy.
+    assert not hasattr(mcp_server, "_surprise_score_mcp"), (
+        "mcp_server should no longer define _surprise_score_mcp; the MCP "
+        "write path must route through _impl._surprise_score to stay in "
+        "sync with the 2.2.3 neutral-fallback fix."
+    )
+    # The name it does expose points at _impl's implementation.
+    assert mcp_server._surprise_score is impl_surprise_score, (
+        "mcp_server._surprise_score must be the canonical _impl._surprise_score, "
+        "not a local shadow."
+    )
+
+
+def test_no_fts_matches_returns_neutral_not_novel(fresh_db):
+    # The original bug: pre-2.4.9, this content with no FTS neighbors
+    # returned (1.0, "fts5_no_matches"); canonical is (0.5,
+    # "fts5_no_matches_neutral") per the 2.2.3 fix.
+    surprise, method = mcp_server._surprise_score(
+        fresh_db, "completely novel content nobody else wrote about"
+    )
+    assert surprise == 0.5
+    assert method == "fts5_no_matches_neutral"
+
+
+def test_empty_content_returns_neutral(fresh_db):
+    surprise, method = mcp_server._surprise_score(fresh_db, "")
+    assert surprise == 0.5
+    assert method == "empty_neutral"

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -699,7 +699,13 @@ class TestDoctorMigrationsCheck:
                             lambda *a, **k: sqlite3.connect(fresh_db))
 
         args = argparse.Namespace(json=True)
-        _impl.cmd_doctor(args)
+        # 2.4.9 (audit I9): doctor now sys.exit(1)s on any issues. A
+        # virgin-tracker fixture surfaces one. Handle both paths so the
+        # JSON payload assertion is the real subject of the test.
+        try:
+            _impl.cmd_doctor(args)
+        except SystemExit:
+            pass
         out = capsys.readouterr().out
         data = json.loads(out)
         assert "migrations" in data
@@ -725,7 +731,12 @@ class TestDoctorMigrationsCheck:
                             lambda *a, **k: sqlite3.connect(str(db)))
 
         args = argparse.Namespace(json=True)
-        _impl.cmd_doctor(args)
+        # See note in test_doctor_json_includes_migrations_section —
+        # SystemExit is expected now that doctor reflects health in $?.
+        try:
+            _impl.cmd_doctor(args)
+        except SystemExit:
+            pass
         out = capsys.readouterr().out
         data = json.loads(out)
         # init_schema.sql has the cumulative effects, so virgin tracker +


### PR DESCRIPTION
## Summary
Second slice of the 2026-04-19 audit fix wave. Lands all remaining HIGHs + six MEDIUMs across retrieval correctness, scoring parity, federation safety, and MCP shape/packaging. Full findings under `docs/audit_2026_04_19/` (shipped in 2.4.8 PR #83); this PR executes items I7–I19 of the plan.

## Fixes
- **Scoring parity** — delete `_surprise_score_mcp`; MCP write path now uses canonical `_impl._surprise_score`. `brain.affect_log` reads `safety_flags` (not `safety_flag`) and stores JSON.
- **Retrieval correctness** — revive dead `rel_strong` gate (F-01); stop `rstrip("s")` before `_graph_expand` (F-03); emit debug entries on events/context FTS-only cascade (F-02); apply `_build_fts_match_expression` at `_reason_l1_search` / `cmd_push` / `Brain.orient()` (F-06, F-07).
- **CLI / diagnostics** — `cmd_doctor` now reports `ok`/exit-code by actual health; `paths.get_db_path()` honors `BRAINCTL_DB` (canonical) with `BRAIN_DB` as deprecated alias.
- **Federation / merge / MCP shape** — `_escape_like` + `ESCAPE '\\'` at 7 LIKE sites; self-merge raises `ValueError`; MCP errors normalized to `{"ok": False, "error": ...}` at 11 sites.
- **Packaging** — three `~/bin/lib/` drop-in deps moved in-tree (`agentmemory.lib.{belief_revision,outcome_eval,quantum_retrieval}`) with legacy fallback preserved. `tool_resolve_conflict` / `tool_access_log_annotate` now work on PyPI installs.

## Test plan
- [x] `pytest tests/ --ignore=tests/bench` — **1866 passed, 28 skipped, 2 xfailed** locally (6 new regression tests)
- [x] `tests/test_mcp_surprise_score_parity.py` (3 tests) — MCP ↔ _impl scoring parity
- [x] `tests/test_audit_2_4_9_regressions.py` (3 tests) — cmd_doctor exit, federation escape, merge self-target
- [ ] **retrieval-quality-gate on CI** — I11/I12/I14/I15 change retrieval output shape. This gate is the signal. Don't `--admin` past a *worse* numbers failure.
- [ ] latency-gate flake per audit A2-F04 is expected noise and safe to admin-merge through.

## Release
Tag `v2.4.9` after merge; PyPI publish parks at the `pypi` environment for manual reviewer approval (security gate shipped in 2.4.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)