### PR TITLE
release: v2.4.10 — audit follow-up (structural cleanup + datetime gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.4.10] — 2026-04-20 — *Audit follow-up: structural cleanup + datetime gate*
+
+Third slice of the 2026-04-19 audit fix wave. Focuses on long-tail
+correctness + hygiene; the larger 2.5.0 items (root `init_schema.sql`
+sync, CE warmup off the latency deque, top-heavy MCP exposure, competitor
+bench rerun) are still outstanding and will land in a coordinated 2.5.0
+release.
+
+### Fixed
+
+- **`datetime.utcnow()` removed everywhere it was being called.** Three
+  sites in `hippocampus.py`, `mcp_server.py`, `mcp_tools_health.py`
+  switched to `datetime.now(timezone.utc)`. The `mcp_tools_health` cutoff
+  for `access_log` pruning was also producing naive ISO strings that
+  sorted incorrectly against Z-suffixed `created_at` rows — under-deletes
+  fixed.
+- **`decision_lookup` intent now actually queries the `decisions`
+  table.** The pre-2.5.0 guard checked `"decisions" not in results`
+  (`results` is pre-initialized with that key — guard always False), and
+  the body's set union didn't include `"decisions"` either. Two-bug fix
+  on a single line. Source-locked by regression test.
+- **`config.load()` no longer silently swallows permission errors.**
+  Bare `except Exception: pass` replaced with `tomllib.TOMLDecodeError`
+  + `OSError` branches that log a warning then fall back to defaults.
+  CLI still boots when `config.toml` is unreadable; the user sees the
+  reason in stderr instead of stale defaults.
+- **`federated_memory_search` / `federated_search` now expose
+  `returned_count`** alongside `total_results` so callers can branch on
+  the slice without inferring from `len(results)`. `total_results`
+  semantics unchanged (full pre-slice match pool).
+
+### Changed — performance + hygiene
+
+- `code_ingest.Extraction.add_node_if_new()` replaces three O(n²)
+  set-comprehension dedup sites in the python / typescript / go
+  extractors. Indistinguishable on small trees, real difference on a
+  100-file ingest.
+- `_cached_score` lru_cache shim removed from `rerank.py` — it had no
+  callers and always returned `None`. Real cache (`_score_cache`
+  dict + eviction list) untouched.
+- Subprocess `stdout=open(...)` replaced with `with open(...)` at the
+  two backup sites (`_impl.py`, `mcp_tools_health.py`) so the fd
+  closes on every exit path, not just success.
+- `bin/quiet-hours-{start,end}.sh` cd into the script dir before
+  invoking the python sibling so cron (which sets CWD=$HOME) finds
+  the file.
+
+### CI
+
+- New `tests/test_datetime_hygiene.py` regex-asserts no `datetime.utcnow()`
+  calls remain anywhere in `src/agentmemory/`. The earlier draft of this
+  gate also tracked bare `datetime.now()` against an allowlist; that
+  half was dropped because line-numbered allowlists drift on every PR
+  that touches a long file. Naked-`now()` cleanup will follow as part
+  of the coordinated local→UTC timestamp migration.
+
+### Testing
+
+`1874 passed, 28 skipped, 2 xfailed` locally. Three new regression
+tests at `tests/test_audit_2_5_0_regressions.py` lock I25, I29, I31.
+
 ## [2.4.9] — 2026-04-20 — *Audit follow-up: retrieval correctness, scoring parity, MCP hygiene*
 
 Second slice of the 2026-04-19 audit fix wave. Ships the remaining HIGHs

--- a/bin/quiet-hours-end.sh
+++ b/bin/quiet-hours-end.sh
@@ -3,4 +3,7 @@
 # Runs at 2:00 PM ET (18:00 UTC) daily via cron
 
 set -euo pipefail
+# Resolve relative to this script so cron (which sets CWD=$HOME)
+# finds the companion .py file. Audit I32.
+cd "$(dirname "$0")"
 exec python3 quiet-hours-end.py

--- a/bin/quiet-hours-start.sh
+++ b/bin/quiet-hours-start.sh
@@ -4,4 +4,7 @@
 # Saves prior state so quiet-hours-end.sh can restore exactly
 
 set -euo pipefail
+# Resolve relative to this script so cron (which sets CWD=$HOME)
+# finds the companion .py file. Audit I32.
+cd "$(dirname "$0")"
 exec python3 quiet-hours-start.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "brainctl"
-version = "2.4.9"
+version = "2.4.10"
 description = "Context engineering for AI agents — persistent memory, knowledge graph, affect tracking, and MCP server. Single SQLite file, zero LLM cost."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/agentmemory/__init__.py
+++ b/src/agentmemory/__init__.py
@@ -9,7 +9,7 @@ Quick start:
     brain.search("preferences")
 """
 
-__version__ = "2.4.9"
+__version__ = "2.4.10"
 
 from agentmemory.brain import Brain
 

--- a/src/agentmemory/_impl.py
+++ b/src/agentmemory/_impl.py
@@ -6203,9 +6203,17 @@ def cmd_search(args, *, db=None, db_path: Optional[str] = None):
     else:
         _intent_result = _builtin_classify_intent(query)
         tables = _intent_result.tables
-    # For decision_lookup intent, ensure decisions table is searched
-    if _intent_result and _intent_result.intent == "decision_lookup" and "decisions" not in results:
-        tables = list(set(tables) | {"memories", "events", "context"})
+    # For decision_lookup intent, ensure decisions table is searched.
+    # Before 2.5.0 this guard checked `"decisions" not in results` — but
+    # `results` is always initialized with a "decisions" key (see the dict
+    # literal near the top of cmd_search), so the `if` body never ran AND
+    # the body itself didn't even add "decisions" to `tables`. Audit I25.
+    if (
+        _intent_result
+        and _intent_result.intent == "decision_lookup"
+        and "decisions" not in tables
+    ):
+        tables = list(set(tables) | {"memories", "events", "context", "decisions"})
     base_fetch = limit * 5 if not no_recency else limit * 3
     fetch_limit = max(limit, round(base_fetch * _nm_breadth))
     # Build an OR-expanded FTS5 MATCH expression so natural-language queries
@@ -8585,7 +8593,11 @@ def cmd_backup(args):
     # Also export to SQL for iCloud-safe backup
     sql_path = BACKUPS_DIR / f"brain_{ts}.sql"
     import subprocess
-    subprocess.run(["sqlite3", str(DB_PATH), ".dump"], stdout=open(str(sql_path), "w"), check=True)
+    # stdout=open(...) without a context manager leaks the fd if the
+    # subprocess raises (audit I30). Use `with` so the file is closed
+    # on CalledProcessError / KeyboardInterrupt / any other exit path.
+    with open(str(sql_path), "w") as _out:
+        subprocess.run(["sqlite3", str(DB_PATH), ".dump"], stdout=_out, check=True)
 
     # Prune old backups (keep last 30)
     backups = sorted(BACKUPS_DIR.glob("brain_*.db"), reverse=True)

--- a/src/agentmemory/code_ingest.py
+++ b/src/agentmemory/code_ingest.py
@@ -136,6 +136,26 @@ class Extraction:
     nodes: List[Node] = field(default_factory=list)
     edges: List[Edge] = field(default_factory=list)
 
+    def add_node_if_new(self, node: "Node") -> bool:
+        """Append ``node`` iff no existing node shares its name.
+
+        Returns True when a node was added, False when deduplicated.
+        Maintains an internal O(1) lookup set so repeated calls stay
+        O(1) instead of the O(n²) per-iteration set-comprehension
+        pattern we replaced in 2.5.0 (audit I26). Callers that append
+        directly to ``.nodes`` bypass dedup — use this helper for any
+        path where duplicates matter (e.g. import targets).
+        """
+        names = getattr(self, "_node_names", None)
+        if names is None:
+            names = {nd.name for nd in self.nodes}
+            self._node_names = names
+        if node.name in names:
+            return False
+        self.nodes.append(node)
+        names.add(node.name)
+        return True
+
 
 @dataclass
 class IngestStats:
@@ -405,9 +425,8 @@ def _emit_python_import(n, src: bytes, file_nm: str, ex: Extraction) -> None:
 
     for modname in mod_names:
         tgt = f"module:{modname}"
-        if tgt not in {nd.name for nd in ex.nodes}:
-            ex.nodes.append(Node(kind="module", name=tgt, label=modname,
-                                 source_file="<external>", language="python"))
+        ex.add_node_if_new(Node(kind="module", name=tgt, label=modname,
+                                source_file="<external>", language="python"))
         ex.edges.append(Edge(file_nm, tgt, "imports", WEIGHT_INFERRED))
 
 
@@ -473,10 +492,9 @@ def extract_typescript(path: Path, src: bytes, relpath: str) -> Extraction:
             if src_node is not None:
                 raw = _node_text(src_node, src).strip("\"'`")
                 tgt = f"module:{raw}"
-                if tgt not in {nd.name for nd in ex.nodes}:
-                    ex.nodes.append(Node(kind="module", name=tgt, label=raw,
-                                         source_file="<external>",
-                                         language="typescript"))
+                ex.add_node_if_new(Node(kind="module", name=tgt, label=raw,
+                                        source_file="<external>",
+                                        language="typescript"))
                 ex.edges.append(Edge(file_nm, tgt, "imports", WEIGHT_INFERRED))
             return
         for c in n.named_children:
@@ -583,9 +601,8 @@ def _emit_go_import_spec(spec, src: bytes, file_nm: str, ex: Extraction) -> None
         return
     raw = _node_text(path_node, src).strip("\"`")
     tgt = f"module:{raw}"
-    if tgt not in {nd.name for nd in ex.nodes}:
-        ex.nodes.append(Node(kind="module", name=tgt, label=raw,
-                             source_file="<external>", language="go"))
+    ex.add_node_if_new(Node(kind="module", name=tgt, label=raw,
+                            source_file="<external>", language="go"))
     ex.edges.append(Edge(file_nm, tgt, "imports", WEIGHT_INFERRED))
 
 

--- a/src/agentmemory/config.py
+++ b/src/agentmemory/config.py
@@ -5,9 +5,12 @@ Config file location: ~/.brainctl/config.toml (or $BRAINCTL_CONFIG).
 """
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 try:
     import tomllib  # Python 3.11+
@@ -79,8 +82,24 @@ def load() -> dict[str, Any]:
                     config[section].update(values)
                 else:
                     config[section] = values
-        except Exception:
-            pass  # malformed config — fall back to defaults
+        except tomllib.TOMLDecodeError as exc:
+            # Malformed TOML — fall back to defaults silently so the CLI
+            # still boots. The user sees defaults every time they run any
+            # brainctl command and will notice the missing overrides.
+            logger.warning(
+                "brainctl: config at %s is not valid TOML, using defaults: %s",
+                cfg_file, exc,
+            )
+        except OSError as exc:
+            # Permission/IO problems were silenced by a bare
+            # `except Exception: pass` before 2.5.0 (audit I29). Surface
+            # via logging but still fall back to defaults so the CLI
+            # boots — a permission-denied config shouldn't brick every
+            # command.
+            logger.warning(
+                "brainctl: cannot read config at %s, using defaults: %s",
+                cfg_file, exc,
+            )
 
     # Apply environment variable overrides
     _apply_env(config)

--- a/src/agentmemory/federation.py
+++ b/src/agentmemory/federation.py
@@ -227,7 +227,18 @@ def federated_memory_search(
 
     # Sort merged results by created_at descending
     results.sort(key=lambda r: r.get("created_at") or "", reverse=True)
-    return {"ok": True, "results": results[:limit], "total_results": len(results)}
+    # total_results counts the pre-slice match pool across all federated
+    # DBs; the returned `results` array is truncated to `limit`. The two
+    # numbers can diverge when matches > limit, which confused callers
+    # branching on `total_results == len(results)` before 2.5.0. Audit
+    # I31 — return `returned_count` alongside so the intent is explicit.
+    sliced = results[:limit]
+    return {
+        "ok": True,
+        "results": sliced,
+        "total_results": len(results),
+        "returned_count": len(sliced),
+    }
 
 
 def federated_entity_search(
@@ -433,9 +444,13 @@ def federated_search(
 
     # Sort merged results by created_at descending
     results.sort(key=lambda r: r.get("created_at") or "", reverse=True)
+    sliced = results[:limit]
+    # See federated_memory_search for the total_results vs
+    # returned_count rationale (audit I31).
     return {
         "ok": True,
-        "results": results[:limit],
+        "results": sliced,
         "db_count": db_count,
         "total_results": len(results),
+        "returned_count": len(sliced),
     }

--- a/src/agentmemory/hippocampus.py
+++ b/src/agentmemory/hippocampus.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import time
 from collections import Counter, defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
@@ -3822,7 +3822,12 @@ def reflexion_propagation_pass(
         "skipped_already_propagated": 0,
     }
 
-    now = datetime.utcnow().isoformat()
+    # datetime.utcnow() is deprecated in Py3.12+ and produces a naive UTC
+    # datetime whose isoformat() output has no timezone marker — which
+    # sorts BEFORE any Z-suffixed string with the same digits
+    # lexicographically. Use the canonical Z-suffixed helper so this
+    # timestamp compares cleanly against other rows in the DB.
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
     for row in rows:
         row = dict(row)

--- a/src/agentmemory/mcp_server.py
+++ b/src/agentmemory/mcp_server.py
@@ -1059,7 +1059,12 @@ def tool_event_add(agent_id: str, summary: str, event_type: str, detail: str = N
         try:
             now_dt = datetime.fromisoformat(now_ts)
         except Exception:
-            now_dt = datetime.utcnow()
+            # Previously datetime.utcnow() — deprecated in Py3.12+ and
+            # produces a naive datetime, which would TypeError when
+            # subtracted from an aware datetime parsed out of `now_ts`
+            # in the happy path. Keep aware UTC here so both branches
+            # feed the arithmetic below the same way.
+            now_dt = datetime.now(timezone.utc)
         window_start = (now_dt - timedelta(hours=_LABILE_RESCUE_WINDOW_HOURS)).strftime("%Y-%m-%dT%H:%M:%S")
         labile_until = (now_dt + timedelta(hours=_LABILE_DURATION_HOURS)).strftime("%Y-%m-%dT%H:%M:%S")
         # SELECT candidate memories rather than bulk-UPDATE, so we can filter

--- a/src/agentmemory/mcp_tools_health.py
+++ b/src/agentmemory/mcp_tools_health.py
@@ -539,7 +539,14 @@ def _lint(fix: bool = False) -> dict:
                 })
                 if fix:
                     from datetime import timedelta
-                    cutoff = (datetime.utcnow() - timedelta(days=30)).isoformat()
+                    # datetime.utcnow() is deprecated in Py3.12+ and the
+                    # naive isoformat() output sorts inconsistently against
+                    # Z-suffixed strings stored in access_log.created_at —
+                    # the DELETE cutoff was always lexicographically earlier
+                    # than real rows, under-deleting old log entries.
+                    cutoff = (
+                        datetime.now(timezone.utc) - timedelta(days=30)
+                    ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
                     cursor = db.execute("DELETE FROM access_log WHERE created_at < ?", (cutoff,))
                     db.commit()
                     fixed += cursor.rowcount
@@ -610,15 +617,19 @@ def _backup(dest_path: str | None = None) -> dict:
 
         shutil.copy2(str(DB_PATH), str(backup_path))
 
-        # Also export to SQL for safer backup
+        # Also export to SQL for safer backup. The previous
+        # `stdout=open(...)` without a context manager leaked the fd on
+        # any subprocess exception (audit I30) — use `with` so the file
+        # closes on every exit path.
         sql_path = backup_path.with_suffix(".sql")
         try:
-            subprocess.run(
-                ["sqlite3", str(DB_PATH), ".dump"],
-                stdout=open(str(sql_path), "w"),
-                check=True,
-                timeout=60,
-            )
+            with open(str(sql_path), "w") as _out:
+                subprocess.run(
+                    ["sqlite3", str(DB_PATH), ".dump"],
+                    stdout=_out,
+                    check=True,
+                    timeout=60,
+                )
             sql_str = str(sql_path)
         except Exception:
             sql_str = None

--- a/src/agentmemory/rerank.py
+++ b/src/agentmemory/rerank.py
@@ -65,7 +65,6 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple
 
 # ---------------------------------------------------------------------------
@@ -271,22 +270,14 @@ def _clear_model_cache() -> None:
 # = 48 bits = ~10^14 distinct values, plenty for 1000-entry cache and
 # negligible collision risk. Full hash would just bloat the cache key.
 
-@lru_cache(maxsize=1000)
-def _cached_score(model_name: str, query_h: str, cand_h: str) -> Optional[float]:
-    """Internal cache shim. Always returns None (cache-miss sentinel)
-    on the first call; the populating logic happens in score_pairs.
+# _cached_score used to exist here as an @lru_cache(maxsize=1000) shim
+# whose docstring claimed score_pairs "writes hits via its inner
+# closure". It didn't — the function had no callers and always
+# returned None regardless. The real score cache is the manual
+# _score_cache dict below. Dead code removed in 2.5.0 (audit I24).
 
-    This function exists purely so functools.lru_cache gives us a
-    stable per-process cache. score_pairs writes hits via its inner
-    closure (see below).
-    """
-    return None
-
-
-# We can't easily set lru_cache entries from outside, so we use a
-# manual dict layered with explicit eviction matching the LRU bound.
-# This keeps the API simple (str keys) and lets tests inspect the
-# cache directly.
+# The explicit dict layered with an eviction list keeps the API
+# simple (str keys) and lets tests inspect the cache directly.
 _score_cache: "Dict[Tuple[str, str, str], float]" = {}
 _score_cache_order: "List[Tuple[str, str, str]]" = []
 _SCORE_CACHE_MAX = 1000

--- a/tests/test_audit_2_5_0_regressions.py
+++ b/tests/test_audit_2_5_0_regressions.py
@@ -1,0 +1,117 @@
+"""Regression locks for the 2.5.0 audit-follow-up fixes.
+
+Locks the I25 / I29 / I31 behavioral fixes so later refactors can't
+silently revert them.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# --- I25: decision_lookup intent actually adds "decisions" to tables -----
+
+def test_decision_lookup_guard_source_is_correct():
+    """Lock the exact fix at _impl.py:6207-ish — the guard must check
+    ``"decisions" not in tables`` (not ``not in results`` — that was
+    always False, because ``results`` is pre-initialized with a
+    "decisions" key), AND the set union must include "decisions" itself.
+
+    A source-level check is the load-bearing lock here: the alternative
+    (reproducing the regression end-to-end through cmd_search) requires
+    stubbing out the intent router, which itself has two branches
+    (_classify_intent vs _builtin_classify_intent) and an optional bin/
+    dependency. A single-line read locks the fix with zero coupling.
+    """
+    impl_path = SRC / "agentmemory" / "_impl.py"
+    src = impl_path.read_text()
+    assert "_intent_result.intent == \"decision_lookup\"" in src, (
+        "decision_lookup intent handling removed — retrieval for that "
+        "intent will regress"
+    )
+    # The correct guard checks `tables`, not `results`.
+    assert '"decisions" not in tables' in src, (
+        "decision_lookup guard must check `\"decisions\" not in tables` — "
+        "pre-2.5.0 it checked `results` which was always initialized with "
+        "that key, making the guard a no-op"
+    )
+    # The body must actually add "decisions" to the tables set union.
+    # Scan the ~15 lines following the guard — the body assignment sits
+    # right after the closing `):`.
+    after_guard = src.split('"decisions" not in tables', 1)[1]
+    body_window = "\n".join(after_guard.splitlines()[:15])
+    assert '"decisions"' in body_window, (
+        "decision_lookup body must include \"decisions\" in the table set "
+        "union — otherwise the guard fires but the decisions table still "
+        "isn't searched (audit I25 second bug)"
+    )
+
+
+# --- I29: config loader surfaces permission/OS errors via logging -------
+
+def test_config_load_falls_back_on_permission_error(tmp_path, monkeypatch, caplog):
+    from agentmemory import config
+
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text("[search]\nlimit = 42\n")
+    cfg_file.chmod(0)  # owner-only permissions removed — read will OSError
+
+    monkeypatch.setenv("BRAINCTL_CONFIG", str(cfg_file))
+    with caplog.at_level("WARNING", logger="agentmemory.config"):
+        try:
+            loaded = config.load()
+        finally:
+            cfg_file.chmod(0o644)  # restore for cleanup
+    # Must fall back to defaults (not crash) and must have logged a warning.
+    assert isinstance(loaded, dict)
+    assert any("cannot read config" in rec.message for rec in caplog.records), (
+        "config.load should log a warning when the config file can't be read"
+    )
+
+
+def test_config_load_falls_back_on_malformed_toml(tmp_path, monkeypatch, caplog):
+    from agentmemory import config
+
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text("this is = not valid = toml = at all")
+    monkeypatch.setenv("BRAINCTL_CONFIG", str(cfg_file))
+    with caplog.at_level("WARNING", logger="agentmemory.config"):
+        loaded = config.load()
+    assert isinstance(loaded, dict)
+    assert any("not valid TOML" in rec.message for rec in caplog.records)
+
+
+# --- I31: federated search reports both total and returned counts --------
+
+def test_federated_memory_search_reports_both_counts(tmp_path, monkeypatch):
+    from agentmemory import federation
+    from agentmemory.brain import Brain
+
+    db = tmp_path / "brain.db"
+    b = Brain(db_path=str(db))
+    # Use a distinctive word that FTS5 tokenizes identically across rows.
+    for i in range(5):
+        b.remember(f"widgetron fixture row {i}", category="lesson")
+
+    monkeypatch.setenv("BRAIN_DB", str(db))
+    monkeypatch.delenv("BRAIN_DB_FEDERATION", raising=False)
+
+    r = federation.federated_memory_search("widgetron", limit=3)
+    assert r["ok"] is True, r
+    assert "returned_count" in r, (
+        "federated_memory_search must expose `returned_count` so callers "
+        "can branch on returned vs total without inferring from len()"
+    )
+    assert r["returned_count"] == len(r["results"]), (
+        "returned_count must equal len(results) by construction"
+    )
+    assert r["returned_count"] <= 3, "returned count must respect the limit"
+    assert r["total_results"] >= r["returned_count"], (
+        "total_results must never undercount the returned slice"
+    )

--- a/tests/test_datetime_hygiene.py
+++ b/tests/test_datetime_hygiene.py
@@ -1,0 +1,50 @@
+"""Datetime hygiene gate — audit I21.
+
+Blocks new uses of ``datetime.utcnow()`` (deprecated in Py3.12+, always
+naive, silently breaks ordering against Z-suffixed DB timestamps).
+
+Deliberately does NOT track bare ``datetime.now()`` right now. An earlier
+draft used a line-numbered allowlist, which produced noise on every PR
+that shuffled lines in the allowlisted files. The naked ``.now()``
+cleanup will come as part of the coordinated local→UTC timestamp
+migration (the one blocked on deciding what to do with hippocampus's
+internal-consistency writers) — gating it before that's done only
+creates churn.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+SRC = Path(__file__).resolve().parent.parent / "src" / "agentmemory"
+
+_UTCNOW_PATTERN = re.compile(r"\bdatetime\.utcnow\(\s*\)")
+
+
+def _walk_py_files():
+    for p in SRC.rglob("*.py"):
+        if "__pycache__" in p.parts:
+            continue
+        yield p
+
+
+def test_no_datetime_utcnow_calls():
+    """datetime.utcnow() is deprecated in Py3.12+ — use datetime.now(timezone.utc)."""
+    offenders: list[str] = []
+    for path in _walk_py_files():
+        rel = path.relative_to(SRC).as_posix()
+        for i, line in enumerate(path.read_text().splitlines(), start=1):
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue  # allow commentary referencing the deprecated name
+            if _UTCNOW_PATTERN.search(line):
+                offenders.append(f"{rel}:{i}: {line.strip()[:80]}")
+    assert not offenders, (
+        "datetime.utcnow() is deprecated in Py3.12+ and produces a naive "
+        "datetime that silently breaks ordering against Z-suffixed DB "
+        "timestamps. Replace with datetime.now(timezone.utc).\n\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Summary
Third slice of the 2026-04-19 audit fix wave. Closes the long-tail correctness + hygiene items that don't require the deeper retrieval/schema migrations queued for **2.5.0** (root `init_schema.sql` sync, CE warmup off latency deque, top-heavy MCP exposure, competitor bench rerun, naked `datetime.now()` cleanup).

## Fixes (8 items + 3 regression tests + CI gate)
- **datetime.utcnow() removed everywhere** (3 sites). The `access_log` cutoff was producing naive ISO strings sorting incorrectly against Z-suffixed `created_at` rows.
- **decision_lookup intent now actually searches the decisions table** — two-bug fix on the guard that was always-False AND missing "decisions" from its body union.
- **config.load() surfaces permission errors** via warning log instead of silently using defaults.
- **federated_*_search exposes `returned_count`** alongside `total_results`.
- **code_ingest O(n²) dedup** → new `Extraction.add_node_if_new()` helper.
- **rerank.py dead `_cached_score`** removed.
- **subprocess fd leak** → `with open(...)` at 2 backup sites.
- **cron CWD bug** → `bin/quiet-hours-*.sh` cd to script dir.
- **CI gate** asserts no `datetime.utcnow()` calls anywhere; line-numbered `now()` allowlist deliberately not added (drifts on every PR — deferred to coordinated local→UTC migration).

## Test plan
- [x] `pytest tests/ --ignore=tests/bench` — **1874 passed, 28 skipped, 2 xfailed** locally
- [x] `tests/test_audit_2_5_0_regressions.py` (3 tests) — locks I25 source-correctness, I29 config error handling, I31 federation count semantics
- [x] `tests/test_datetime_hygiene.py` (1 test, regex-based) — blocks new `datetime.utcnow()` introductions
- [ ] **retrieval-quality-gate** — I25 changes retrieval (`decision_lookup` intent now actually adds the table). Read the numbers, don't `--admin` past a real regression
- [ ] latency-gate flake per A2-F04 expected; admin-merge through

## Versioning note
Plan tracks 15 items for 2.5.0; this PR ships 8. Reserving `v2.5.0` for the coordinated retrieval/schema work + competitor bench rerun. CHANGELOG explicitly notes what's deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)