### PR TITLE
fix(mcp): adapt dispatcher call shape so agent_id stops breaking extension tools

### DIFF
--- a/src/agentmemory/mcp_server.py
+++ b/src/agentmemory/mcp_server.py
@@ -12,6 +12,7 @@ Usage:
   brainctl-mcp --doctor --json  # also output JSON results
 """
 
+import inspect
 import json
 import logging
 import os
@@ -2872,6 +2873,38 @@ def tool_affect_monitor(agent_id="mcp-client", **kw):
 app = Server("brainctl")
 
 
+def _invoke_dispatch_fn(fn, agent_id: str, arguments: dict):
+    """Call a tool dispatcher, adapting to its signature.
+
+    Two extension-module conventions exist alongside the native
+    ``fn(agent_id=..., **kwargs)`` shape: a ``fn(args: dict)`` shape used by
+    `mcp_tools_health` and `mcp_tools_lifecycle`. Without introspection,
+    blindly calling ``fn(agent_id=..., **arguments)`` fails on the latter
+    with ``unexpected keyword argument 'agent_id'`` and breaks `health`,
+    `lint`, `validate`, `decay_report`, etc. (issue #97).
+    """
+    try:
+        params = list(inspect.signature(fn).parameters.values())
+    except (TypeError, ValueError):
+        params = None
+
+    single_dict_arg = (
+        params is not None
+        and len(params) == 1
+        and params[0].kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    )
+
+    if single_dict_arg:
+        args_dict = dict(arguments)
+        args_dict.setdefault("agent_id", agent_id)
+        return fn(args_dict)
+
+    return fn(agent_id=agent_id, **arguments)
+
+
 @app.list_tools()
 async def list_tools() -> list[Tool]:
     return TOOLS
@@ -2935,7 +2968,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         if name == "stats":
             result = fn()
         else:
-            result = fn(agent_id=agent_id, **arguments)
+            result = _invoke_dispatch_fn(fn, agent_id, arguments)
     except Exception as e:
         result = {"error": str(e)}
 

--- a/tests/test_mcp_dispatch_signature.py
+++ b/tests/test_mcp_dispatch_signature.py
@@ -1,0 +1,103 @@
+"""Tests for the MCP server dispatch signature adapter.
+
+Regression coverage for issue #97 — the MCP wrapper used to inject
+``agent_id`` into every tool call regardless of whether the dispatcher
+function accepted it. Extension modules (`mcp_tools_health`,
+`mcp_tools_lifecycle`) define their dispatchers as ``_call_X(args: dict)``
+and rejected the kwarg with::
+
+    _call_health() got an unexpected keyword argument 'agent_id'
+
+`_invoke_dispatch_fn` introspects the callable and adapts the call shape
+so both conventions work.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import pytest
+
+mcp_server = pytest.importorskip("agentmemory.mcp_server")
+_invoke = mcp_server._invoke_dispatch_fn
+
+
+def test_native_kwarg_style_receives_agent_id():
+    seen = {}
+
+    def fn(agent_id: str, foo: int = 0, **kw):
+        seen["agent_id"] = agent_id
+        seen["foo"] = foo
+        seen["kw"] = kw
+        return {"ok": True}
+
+    out = _invoke(fn, "claude", {"foo": 7, "bar": "x"})
+    assert out == {"ok": True}
+    assert seen["agent_id"] == "claude"
+    assert seen["foo"] == 7
+    assert seen["kw"] == {"bar": "x"}
+
+
+def test_extension_args_dict_style_does_not_receive_agent_id_kwarg():
+    """Regression: ``_call_health(args: dict)`` etc. must not crash."""
+    seen = {}
+
+    def _call_health(args: dict) -> dict:
+        seen["args"] = args
+        return {"ok": True, "args": args}
+
+    out = _invoke(_call_health, "claude", {"window_days": 14})
+    assert out["ok"] is True
+    # agent_id is folded into the args dict so extensions can opt-in to it
+    assert seen["args"]["window_days"] == 14
+    assert seen["args"]["agent_id"] == "claude"
+
+
+def test_extension_args_dict_does_not_overwrite_explicit_agent_id():
+    seen = {}
+
+    def _call_x(args: dict) -> dict:
+        seen.update(args)
+        return {}
+
+    _invoke(_call_x, "fallback-agent", {"agent_id": "explicit", "k": 1})
+    assert seen["agent_id"] == "explicit"
+    assert seen["k"] == 1
+
+
+def test_var_kwargs_lambda_routes_to_kwarg_style():
+    """``lambda **kw: ...`` is a single-param signature but VAR_KEYWORD,
+    so it must take the kwarg path, not the args-dict path.
+    """
+    seen = {}
+
+    def fn(**kw):
+        seen.update(kw)
+        return {}
+
+    _invoke(fn, "ag", {"a": 1, "b": 2})
+    assert seen == {"agent_id": "ag", "a": 1, "b": 2}
+
+
+def test_real_health_dispatcher_does_not_crash():
+    """Smoke test against the actual ``_call_health`` from
+    ``mcp_tools_health`` — the original failure site reported in #97.
+
+    We don't assert on payload (it depends on a brain.db) — only that the
+    call completes without raising the historical TypeError.
+    """
+    health_mod = pytest.importorskip("agentmemory.mcp_tools_health")
+    fn = health_mod.DISPATCH["health"]
+    try:
+        _invoke(fn, "test-agent", {"window_days": 1})
+    except TypeError as e:
+        if "agent_id" in str(e):
+            pytest.fail(f"agent_id wrapper bug regressed: {e}")
+        raise
+    except Exception:
+        # other exceptions (db missing, etc.) are out of scope here
+        pass


### PR DESCRIPTION
## Summary
- Fixes the agent_id wrapper bug reported in #97 — at least 10 MCP tools (`health`, `lint`, `validate`, `backup`, `budget_status`, `decay_report`, `lifecycle_summary`, `write_gate_stats`, `consolidation_events`, `retirement_analysis`) currently fail with `_call_X() got an unexpected keyword argument 'agent_id'`.
- Adds `_invoke_dispatch_fn` to introspect each dispatcher and adapt the call shape for the two coexisting conventions:
  - native: `fn(agent_id=..., **kwargs)`
  - extension single-dict: `fn(args: dict)` (used by `mcp_tools_health`, `mcp_tools_lifecycle`)
- New focused unit tests in `tests/test_mcp_dispatch_signature.py` cover both shapes plus the `lambda **kw: ...` edge case.

## Why this happened
`call_tool` in `mcp_server.py` unconditionally did `fn(agent_id=agent_id, **arguments)`. That works for the native shape and for `**kwargs` lambdas, but extension dispatchers `_call_health(args: dict)` etc. take a single positional dict and reject the kwarg. Whoever wired the extension modules picked a different convention than the core, and the dispatch site never accommodated it.

## What this PR does
- Introspects the callable's signature once per call. If it has exactly one positional/positional-or-keyword parameter, the dispatcher is called with `arguments` as a single dict (with `agent_id` folded in via `setdefault` so an explicit `agent_id` in `arguments` still wins).
- Everything else (native style, `**kwargs` lambdas, multi-arg lambdas) goes through the existing `fn(agent_id=agent_id, **arguments)` path unchanged.
- The `stats` shortcut (`fn()` with no arguments) is preserved.

## Out of scope (followups for #97)
This PR fixes the headline wrapper bug. The other items in the issue (FTS index not surviving cold start, `handoff_latest` defaulting to `pending` and missing pinned packets, `infer` finding L1 evidence but reporting empty conclusion, `think` empty seeds, `gaps_scan` false positives, `multi_pass` enrichment breadth) are independent issues and warrant their own PRs.

## Test plan
- [x] `pytest tests/test_mcp_dispatch_signature.py -v` — 5 passed
- [x] `pytest tests/test_mcp_integration.py tests/test_mcp_helpers.py -x` — 36 passed, 1 skipped
- [ ] CI green

Closes part of #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)