### PR TITLE
docs(onboarding): document service-launched env propagation requirement

### DIFF
--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -195,6 +195,48 @@ Schedule periodic consolidation (decay, compress, promote):
 0 */4 * * * BRAIN_DB=~/agentmemory/db/brain.db brainctl-consolidate cycle
 ```
 
+## Environment Variables
+
+brainctl resolves the database location at process start. The relevant env vars:
+
+| Variable | Purpose |
+|---|---|
+| `BRAINCTL_HOME` | Root for `db/brain.db`, `backups/`, etc. Defaults to `~/agentmemory`. |
+| `BRAIN_DB` | Direct path to a `brain.db` file. Overrides `BRAINCTL_HOME`. |
+| `BRAIN_DB_FEDERATION` | Federated multi-DB routing config (multi-profile setups). |
+
+### Service-launched processes (systemd, launchd, gateway daemons)
+
+These vars are read **once at process start** from the process environment.
+A long-lived service (systemd unit, launchd plist, supervisor entry, custom
+gateway) does **not** inherit interactive shell exports. If you set
+`BRAINCTL_HOME` in `~/.zshrc` and the service is launched separately,
+interactive `brainctl …` calls hit the right DB but the service writes to
+the default location instead — a silent split-brain.
+
+When integrating brainctl into a service definition:
+
+- **systemd** — declare the vars with `Environment=` (or `EnvironmentFile=`)
+  in the unit, e.g. `Environment=BRAINCTL_HOME=/var/lib/brainctl`.
+- **launchd** — set them under `EnvironmentVariables` in the plist.
+- **Hermes gateway / OpenClaw / similar agent runtimes** — verify the
+  service generator propagates `BRAINCTL_HOME` / `BRAIN_DB` /
+  `BRAIN_DB_FEDERATION` into the generated unit. Profile `.env` and
+  `config.yaml` only help if the runner forwards them. (Tracked upstream
+  in [hermes-agent#13246](https://github.com/NousResearch/hermes-agent/pull/13246);
+  history in brainctl issue #89.)
+
+To confirm at runtime, check what the running process actually sees:
+
+```bash
+brainctl stats              # interactive shell
+ps -eo pid,comm,etime | grep <service>
+cat /proc/<pid>/environ | tr '\0' '\n' | grep -E 'BRAIN(_DB|CTL_HOME)'
+```
+
+If the service env is empty or different from your shell, the unit is
+not propagating — fix it there, not in brainctl.
+
 ## Common Patterns
 
 ### Autonomous Agent (long-running, self-directed)


### PR DESCRIPTION
## Summary
Closes #89 by adding an Environment Variables section to `docs/AGENT_ONBOARDING.md` covering:
- What `BRAINCTL_HOME`, `BRAIN_DB`, and `BRAIN_DB_FEDERATION` actually do
- Why systemd / launchd / agent-runtime services silently end up with the wrong DB when these vars are only set in interactive shells
- How to declare them in unit files (`Environment=` / `EnvironmentFile=` / `EnvironmentVariables`)
- A runtime check (`/proc/<pid>/environ`) to confirm the process sees what you think it sees
- Link back to the upstream Hermes fix (NousResearch/hermes-agent#13246) and this issue for history

## Why this PR exists
Issue #89 came out of a real Hermes profile-isolation migration where interactive shells were correctly routed but the service-launched gateway booted against the default brain.db. The Hermes-side fix is upstream; this PR captures the gotcha on the brainctl side so the next integrator doesn't lose half a day to it.

## Test plan
- [x] Markdown renders cleanly (table + code fences)
- [x] No code changes; CI is purely markdown lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)