### PR TITLE
fix(lifecycle): skip SIGHUP on Windows in install_signal_handlers

### DIFF
--- a/src/agentmemory/lib/lifecycle.py
+++ b/src/agentmemory/lib/lifecycle.py
@@ -145,13 +145,17 @@ def install_signal_handlers() -> bool:
         os._exit(0)
 
     installed_any = False
-    for sig in (signal.SIGTERM, signal.SIGHUP):
+    candidates = [signal.SIGTERM]
+    sighup = getattr(signal, "SIGHUP", None)
+    if sighup is not None:
+        candidates.append(sighup)
+    for sig in candidates:
         try:
             signal.signal(sig, _handler)
             installed_any = True
         except Exception:
             # Some signals are not settable from non-main threads or
-            # on some platforms (e.g. SIGHUP on Windows). Soft-fail.
+            # on some platforms. Soft-fail.
             pass
     _SIGNALS_INSTALLED = installed_any
     return installed_any

--- a/tests/test_mcp_lifecycle.py
+++ b/tests/test_mcp_lifecycle.py
@@ -279,3 +279,20 @@ def test_signal_handler_calls_os_exit(monkeypatch):
 
     handlers[signal.SIGTERM](signal.SIGTERM, None)
     assert exit_calls == [0]
+
+
+def test_install_signal_handlers_skips_missing_sighup(monkeypatch):
+    """On Windows ``signal.SIGHUP`` is absent. Looking it up inside the
+    iterable raised ``AttributeError`` before the try/except could run,
+    so the call crashed at import-time of the MCP server."""
+    handlers = {}
+
+    def fake_signal(sig, handler):
+        handlers[sig] = handler
+        return None
+
+    monkeypatch.setattr(lifecycle.signal, "signal", fake_signal)
+    monkeypatch.delattr(lifecycle.signal, "SIGHUP", raising=False)
+
+    assert lifecycle.install_signal_handlers() is True
+    assert signal.SIGTERM in handlers


### PR DESCRIPTION
Fixes #107.

The tuple `(signal.SIGTERM, signal.SIGHUP)` is materialized before the
loop body's `try`/`except` can run, so `signal.SIGHUP` raises
`AttributeError` at iterable-construction time on Windows. The comment
in the `except` already anticipates this case, but the lookup never
reaches it: the MCP server crashes at startup with the stack trace in
#107.

Build the candidate list with `getattr(signal, "SIGHUP", None)` so the
Windows case becomes a clean skip and POSIX behavior is unchanged.

Test: `tests/test_mcp_lifecycle.py::test_install_signal_handlers_skips_missing_sighup`
deletes `signal.SIGHUP` via monkeypatch and asserts the handler still
installs cleanly. Fails on `main`, passes after the fix.