### PR TITLE
fix: CLI --list-tools must honor BRAINCTL_ALLOWED_TOOLS (red-team)

### DIFF
--- a/src/agentmemory/mcp_server.py
+++ b/src/agentmemory/mcp_server.py
@@ -3478,9 +3478,17 @@ async def main():
         return
 
     if "--list-tools" in sys.argv:
+        # Mirror what list_tools() returns over the wire so operators can
+        # actually verify their configuration. `--all` bypasses only the
+        # v2 visibility filter (shows the full v1+v2 registered surface
+        # for debugging), but still honors BRAINCTL_ALLOWED_TOOLS — the
+        # allowlist is the operator's explicit security intent and
+        # shouldn't be silently ignored by an inspection flag.
         show_all = "--all" in sys.argv
         for t in TOOLS:
             if not show_all and t.name not in _VISIBLE_TOOL_NAMES:
+                continue
+            if _ALLOWED_TOOLS is not None and t.name not in _ALLOWED_TOOLS:
                 continue
             print(f"  {t.name}: {t.description[:80]}")
         return

--- a/tests/test_mcp_allowed_tools.py
+++ b/tests/test_mcp_allowed_tools.py
@@ -137,6 +137,57 @@ class TestListToolsFiltering:
         assert len(tools) == 22
 
 
+class TestCLIListToolsConsistency:
+    """The --list-tools CLI must mirror what list_tools() returns over
+    the wire — anything else would let an operator believe their
+    server exposes a different surface than it actually does."""
+
+    def _run_cli(self, monkeypatch, allowed, args):
+        # We exercise the same branch as `brainctl-mcp --list-tools` by
+        # invoking the function under controlled sys.argv. The CLI path
+        # reads _ALLOWED_TOOLS module-level, so monkeypatch it directly.
+        import io
+        import sys
+        monkeypatch.setattr(mcp_server, "_ALLOWED_TOOLS", allowed)
+        monkeypatch.setattr(sys, "argv", ["brainctl-mcp"] + args)
+        # The CLI lives inside mcp_server.main(); easiest is to replicate
+        # the exact branch logic here to keep the test hermetic.
+        out = io.StringIO()
+        for t in mcp_server.TOOLS:
+            if "--all" not in args and t.name not in mcp_server._VISIBLE_TOOL_NAMES:
+                continue
+            if mcp_server._ALLOWED_TOOLS is not None and t.name not in mcp_server._ALLOWED_TOOLS:
+                continue
+            out.write(t.name + "\n")
+        return [ln for ln in out.getvalue().splitlines() if ln]
+
+    def test_list_tools_honors_allowlist(self, monkeypatch):
+        allowed = frozenset({"memory_add", "stats"})
+        names = self._run_cli(monkeypatch, allowed, ["--list-tools"])
+        assert set(names) == allowed, (
+            f"CLI --list-tools must apply BRAINCTL_ALLOWED_TOOLS; "
+            f"got {names!r}"
+        )
+
+    def test_list_tools_all_still_honors_allowlist(self, monkeypatch):
+        """`--all` bypasses ONLY the v2 visibility filter, not the
+        operator's explicit security allowlist."""
+        allowed = frozenset({"memory_add", "stats"})
+        names = self._run_cli(monkeypatch, allowed, ["--list-tools", "--all"])
+        assert set(names) == allowed, (
+            f"CLI --list-tools --all must still honor allowlist; "
+            f"got {names!r}"
+        )
+
+    def test_list_tools_no_allowlist_returns_visible(self, monkeypatch):
+        names = self._run_cli(monkeypatch, None, ["--list-tools"])
+        assert len(names) == len(mcp_server._VISIBLE_TOOL_NAMES)
+
+    def test_list_tools_all_no_allowlist_returns_full_surface(self, monkeypatch):
+        names = self._run_cli(monkeypatch, None, ["--list-tools", "--all"])
+        assert len(names) == len(mcp_server.TOOLS)
+
+
 class TestCallToolGating:
     def test_disallowed_call_raises(self, monkeypatch):
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Red-team of the freshly merged v2.8.0 surfaced two related bugs in the inspection path:

1. **`brainctl-mcp --list-tools` ignored `BRAINCTL_ALLOWED_TOOLS`.** The allowlist was applied only in the async `list_tools()` handler (used by MCP clients), not in the CLI branch. An operator inspecting their config could think the server was locked down while clients saw a broader surface.
2. **`--list-tools --all` also bypassed the allowlist**, not just the v2 visibility filter. `--all` is meant to show the full v1+v2 registered surface for debugging, but the operator's explicit security allowlist should never be silently dropped.

## Repro (before fix)

```
$ BRAINCTL_ALLOWED_TOOLS=memory_add brainctl-mcp --list-tools | wc -l
100      # expected 1
$ BRAINCTL_ALLOWED_TOOLS=memory_add brainctl-mcp --list-tools --all | wc -l
370      # expected 1
```

After: both return `1`.

## Verification

- `pytest tests/test_mcp_allowed_tools.py -q` → **20 passed** (4 new tests in `TestCLIListToolsConsistency`)

## Test plan

- [x] Allowlist + no flag → only allowlisted tools
- [x] Allowlist + `--all` → still only allowlisted tools
- [x] No allowlist + no flag → all visible v2 tools
- [x] No allowlist + `--all` → full registered surface