### PR TITLE
fix(fts): populate the memories_fts index on init so search works without a manual rebuild

### DIFF
--- a/db/migrations/084_fts_cold_start_rebuild.sql
+++ b/db/migrations/084_fts_cold_start_rebuild.sql
@@ -1,0 +1,22 @@
+-- Migration 084: rebuild memories_fts on cold-start (issue #151)
+--
+-- External-content FTS5 (memories_fts, content=memories) starts with an
+-- empty inverted index. Fresh installs never seeded it, so `memory add`
+-- followed by `search` returned nothing until a manual rebuild. cmd_init
+-- now seeds the index for new DBs; this migration repairs DBs already
+-- created without a seeded index.
+--
+-- An empty external-content index is *consistent*, not *corrupt*, so the
+-- startup integrity-check never flagged it — the rebuild here is the fix.
+--
+-- Rollback:
+--   DELETE FROM schema_version WHERE version = 84;
+--   (the rebuild leaves no schema change to revert)
+--
+-- IDEMPOTENT.
+
+INSERT INTO memories_fts(memories_fts) VALUES('rebuild');
+
+INSERT OR IGNORE INTO schema_version (version, description, applied_at)
+VALUES (84, 'rebuild memories_fts on cold-start (issue #151)',
+        strftime('%Y-%m-%dT%H:%M:%S', 'now'));

--- a/src/agentmemory/_impl.py
+++ b/src/agentmemory/_impl.py
@@ -9720,6 +9720,15 @@ def cmd_init(args):
         tables = [r[0] for r in conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
         ).fetchall()]
+        # Seed the external-content FTS5 inverted index (issue #151). A fresh
+        # memories_fts starts empty; without this rebuild the index is never
+        # primed, and subsequent adds + searches on the CLI path return
+        # nothing until a manual rebuild.
+        try:
+            conn.execute("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')")
+            conn.commit()
+        except sqlite3.Error:
+            pass  # memories_fts may be absent in a minimal/partial schema
         conn.close()
 
         json_out({

--- a/src/agentmemory/mcp_server.py
+++ b/src/agentmemory/mcp_server.py
@@ -331,6 +331,28 @@ def _ensure_fts_index_consistent(conn) -> bool:
     if not active:
         return False
 
+    # Cold-start / under-populated case (issue #151): an external-content
+    # FTS5 index that was never seeded is *empty*, not *corrupt*, so
+    # 'integrity-check' below passes and the rows stay unfindable. The
+    # ``memories_fts_docsize`` shadow table holds one row per indexed
+    # document; when it lags the active-indexed count, the inverted index
+    # is missing documents and must be rebuilt.
+    try:
+        indexed_docs = conn.execute(
+            "SELECT count(*) FROM memories_fts_docsize"
+        ).fetchone()[0]
+    except sqlite3.Error:
+        indexed_docs = None
+    if indexed_docs is not None and indexed_docs < active:
+        try:
+            conn.execute(
+                "INSERT INTO memories_fts(memories_fts) VALUES('rebuild')"
+            )
+            conn.commit()
+            return True
+        except sqlite3.Error:
+            return False
+
     try:
         conn.execute(
             "INSERT INTO memories_fts(memories_fts) VALUES('integrity-check')"

--- a/tests/test_fts_cold_start_init.py
+++ b/tests/test_fts_cold_start_init.py
@@ -1,0 +1,161 @@
+"""Tests for FTS index seeding on cold-start ``init`` (issue #151).
+
+External-content FTS5 (``memories_fts``, ``content=memories``) starts with an
+empty inverted index. ``cmd_init`` applied migrations but never seeded the
+index, and ``_ensure_fts_index_consistent`` only rebuilt when the FTS5
+``'integrity-check'`` raised — an *empty* index is consistent, not corrupt,
+so a populated-but-unindexed DB returned nothing from ``search`` with no
+error.
+
+Scope: the init-seed + under-population auto-heal + repair migration. (The
+CLI ``add`` -> ``search`` end-to-end path additionally depends on the scoped
+memories_fts update triggers from issue #152 / PR #166 — the unscoped
+triggers erode a freshly inserted entry via post-insert metadata UPDATEs —
+so that flow is not asserted here.)
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+mcp_server = pytest.importorskip("agentmemory.mcp_server")
+
+MIGRATION_084 = ROOT / "db" / "migrations" / "084_fts_cold_start_rebuild.sql"
+
+BRAINCTL = [
+    sys.executable,
+    "-c",
+    "import sys; sys.path.insert(0, 'src'); from agentmemory.cli import main; "
+    "sys.argv = ['brainctl'] + sys.argv[1:]; main()",
+]
+
+
+def _run_brainctl(*args, db_path=None):
+    env = os.environ.copy()
+    if db_path:
+        env["BRAIN_DB"] = db_path
+    result = subprocess.run(
+        BRAINCTL + list(args), capture_output=True, text=True, cwd=str(ROOT), env=env
+    )
+    assert result.returncode == 0, f"{args}: {result.stderr}\n{result.stdout}"
+    return result.stdout.strip()
+
+
+def test_cmd_init_seeds_fts_index(tmp_path):
+    """A fresh ``init`` must prime the external-content FTS5 index: every
+    content row is indexed (docsize == memories count, non-empty)."""
+    db = str(tmp_path / "brain.db")
+    _run_brainctl("init", "--path", db)
+
+    conn = sqlite3.connect(db)
+    docsize = conn.execute("SELECT count(*) FROM memories_fts_docsize").fetchone()[0]
+    mem = conn.execute("SELECT count(*) FROM memories").fetchone()[0]
+    conn.close()
+
+    assert mem > 0, "init seeds at least one memory row"
+    assert docsize == mem, "every content row must be in the FTS index after init"
+
+
+def _seed_unindexed(db_path: Path) -> sqlite3.Connection:
+    """Minimal memories + external-content memories_fts with an EMPTY index
+    (mirrors init_schema.sql; the FTS inverted index is never rebuilt)."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE memories (
+            id INTEGER PRIMARY KEY, agent_id TEXT, content TEXT,
+            category TEXT, tags TEXT, indexed INTEGER DEFAULT 1, retired_at INTEGER
+        );
+        CREATE VIRTUAL TABLE memories_fts USING fts5(
+            content, category, tags,
+            content=memories, content_rowid=id,
+            tokenize='porter unicode61'
+        );
+        CREATE TABLE schema_version (
+            version INTEGER PRIMARY KEY, description TEXT, applied_at TEXT
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO memories(id, agent_id, content, category, tags) VALUES (?,?,?,?,?)",
+        [
+            (1, "alice", "Kelly village infrastructure overview", "project", ""),
+            (2, "alice", "Howler playtime morning routine", "preference", ""),
+            (3, "alice", "API rate limits 100/15s", "integration", ""),
+        ],
+    )
+    conn.commit()
+    return conn
+
+
+def test_ensure_consistent_rebuilds_underpopulated_index(tmp_path):
+    """Helper must rebuild when the index is under-populated (docsize <
+    active-indexed count), not only when integrity-check raises.
+
+    On the pre-fix code an empty external-content index is 'consistent',
+    so the helper returned False and the memories stayed unfindable.
+    """
+    db_path = tmp_path / "brain.db"
+    conn = _seed_unindexed(db_path)
+
+    pre = conn.execute(
+        "SELECT count(*) FROM memories_fts WHERE memories_fts MATCH 'kelly'"
+    ).fetchone()[0]
+    assert pre == 0, "precondition: empty index must not MATCH"
+
+    rebuilt = mcp_server._ensure_fts_index_consistent(conn)
+    assert rebuilt is True
+
+    post = conn.execute(
+        "SELECT count(*) FROM memories_fts WHERE memories_fts MATCH 'kelly'"
+    ).fetchone()[0]
+    assert post == 1
+
+
+def test_ensure_consistent_no_rebuild_when_fully_indexed(tmp_path):
+    """When docsize already matches the active count and the index is
+    healthy, the helper is a no-op (guards against needless rebuilds)."""
+    db_path = tmp_path / "brain.db"
+    conn = _seed_unindexed(db_path)
+    conn.execute("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')")
+    conn.commit()
+
+    assert mcp_server._ensure_fts_index_consistent(conn) is False
+
+
+def test_migration_084_rebuilds_unindexed_db(tmp_path):
+    """Applying migration 084 to a populated-but-unindexed DB rebuilds the
+    FTS index and records the version (idempotent)."""
+    db_path = tmp_path / "brain.db"
+    conn = _seed_unindexed(db_path)
+    sql = MIGRATION_084.read_text()
+
+    conn.executescript(sql)
+    conn.commit()
+
+    hits = conn.execute(
+        "SELECT count(*) FROM memories_fts WHERE memories_fts MATCH 'kelly'"
+    ).fetchone()[0]
+    assert hits == 1
+    ver = conn.execute(
+        "SELECT count(*) FROM schema_version WHERE version = 84"
+    ).fetchone()[0]
+    assert ver == 1
+
+    # idempotent re-apply
+    conn.executescript(sql)
+    conn.commit()
+    assert conn.execute(
+        "SELECT count(*) FROM schema_version WHERE version = 84"
+    ).fetchone()[0] == 1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -72,7 +72,7 @@ class TestInitThenUse:
         data = json.loads(out)
         assert data.get("ok") is True or data.get("memory_id") is not None
 
-    @pytest.mark.xfail(reason="FTS5 content-external table index-build timing issue on some SQLite versions — known issue, does not affect production (Brain.search works)")
+    @pytest.mark.xfail(reason="CLI cold-start add->search needs BOTH the init FTS seed (#151) AND the scoped memories_fts update triggers (#152/PR #166): unscoped triggers erode the fresh entry via post-insert metadata UPDATEs. Passes once #166 also lands.")
     def test_search_after_add(self, fresh_db):
         run_brainctl("-a", "tester", "memory", "add", "searchable content here",
                      "-c", "lesson", "--force", db_path=fresh_db)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -334,7 +334,6 @@ def test_decision_with_entity(mcp_db):
 # Scenario 8: MCP tool dispatch round-trip (memory add → search)
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(reason="FTS5 content-external table index-build timing issue on some SQLite versions — known issue, does not affect production (Brain.search works)")
 def test_mcp_memory_add_and_search(mcp_db):
     """Use MCP tools for the full add → search cycle via FTS."""
     db_file, brain = mcp_db


### PR DESCRIPTION
External-content FTS5 (memories_fts, content=memories) starts with an empty
inverted index. cmd_init applied migrations but never seeded it, and
_ensure_fts_index_consistent only rebuilt when 'integrity-check' raised — an
empty index is consistent, not corrupt, so a populated-but-unindexed DB
returned nothing from search with no error.

- cmd_init: rebuild memories_fts after migrations so fresh DBs are primed
- _ensure_fts_index_consistent: detect under-population (memories_fts_docsize
  count < active indexed rows) and rebuild, not only on integrity-check failure
- migration 084: repair DBs already created without a seeded index

Resolves the scenario-8 MCP add->search integration xfail (the search path now
heals a missing index deterministically instead of relying on version-dependent
incremental-index timing).

Refs bug #151 — brainctl init does not populate the FTS5 inverted index
(memory_search returns empty until a manual rebuild):
https://github.com/TSchonleber/brainctl/issues/151

Full CLI add->search resolution also requires the scoped memories_fts update
triggers from PR #166 (fix for bug #152) — on the unscoped triggers, post-insert
metadata UPDATEs erode the freshly inserted entry. Until #166 lands, the CLI
add->search path stays xfail; this PR fixes the init-seed, the MCP-search path,
and the auto-heal for genuinely empty indexes.
